### PR TITLE
ENH: Add mne-kit-gui

### DIFF
--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -70,7 +70,7 @@ specs:
   - mne-kit-gui ~=1.0.1
   - autoreject ~=0.3
   # Python
-  - python >=3.9
+  - python >=3.10
   - pip
   - conda
   - mamba

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -70,7 +70,7 @@ specs:
   - mne-kit-gui ~=1.0.1
   - autoreject ~=0.3
   # Python
-  - python =3.10
+  - python >=3.9
   - pip
   - conda
   - mamba

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -67,6 +67,7 @@ specs:
   - mne-rsa ~=0.6.0
   - mne-microstates ~=0.3.0
   - mne-ari ~=0.1.0
+  - mne-kit-gui ~=1.0.1
   - autoreject ~=0.3
   # Python
   - python =3.10

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -42,3 +42,16 @@ raw = mne.io.RawArray(np.zeros((1, 1000)), mne.create_info(1, 1000., 'eeg'))
 fig = raw.plot()
 fig.close()
 assert 'PyQtGraphBrowser' in repr(fig), repr(fig)
+
+# mne-kit-gui
+from pyface.api import GUI  # noqa
+import mne_kit_gui
+os.setenv('_MNE_GUI_TESTING_MODE', 'true')
+gui = GUI()
+gui.process_events()
+ui, frame = mne_kit_gui.kit2fiff()
+assert not frame.model.can_save
+assert frame.model.stim_threshold == 1.
+frame.model.stim_threshold = 10.
+frame.model.stim_chs = 'save this!'
+ui.dispose()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -45,13 +45,10 @@ assert 'PyQtGraphBrowser' in repr(fig), repr(fig)
 
 # mne-kit-gui
 from pyface.api import GUI  # noqa
-import mne_kit_gui
-os.setenv('_MNE_GUI_TESTING_MODE', 'true')
+import mne_kit_gui  # noqa
+os.environ['_MNE_GUI_TESTING_MODE'] = 'true'
 gui = GUI()
 gui.process_events()
 ui, frame = mne_kit_gui.kit2fiff()
 assert not frame.model.can_save
-assert frame.model.stim_threshold == 1.
-frame.model.stim_threshold = 10.
-frame.model.stim_chs = 'save this!'
 ui.dispose()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -8,6 +8,7 @@ import mne_features
 import mne_rsa
 import mne_microstates
 import mne_ari
+import mne_kit_gui
 # import autoreject
 import darkdetect
 import qdarkstyle


### PR DESCRIPTION
I expect this *not* to work because `mayavi` will probably break everything, but we'll see!

@hoechenberger to be safer it might be good to have a few other minimal tests that we run for the installers to make sure our main GUI frameworks are not broken (I expect these are the most likely things to be broken):

- [x] `matplotlib`: just do `plt.subplots()` or something and make sure it works (#83)
- [x] `matplotlib`: set the backend to QtAgg, make sure it works (#83)
- [x] `pyvistaqt`: test the Qt backend by opening a BackgroundPlotter, adding a mesh, and taking a screenshot (#83)
- [x] `pyvistaqt`: test notebook backend the same was as Qt (#83)
- [x] bump back to Python 3.10
- [x] wait for https://github.com/conda-forge/mayavi-feedstock/pull/59 to land and be uploaded
- [x] merge #83
- [x] rebase this PR
- [x] `mne-kit-gui` (should be done in this PR): open an instance of the coreg gui
- [x] wait for https://github.com/conda-forge/pyface-feedstock/pull/30

This sort of stuff will be especially useful as we try to add support for MNELAB, which uses Qt6 (?), and add abstractions like https://github.com/mne-tools/mne-python/pull/10430.

If you agree these would be useful, I'll open a separate PR for the first four items above. It'll probably require a little bit of CI tweaking to get OpenGL working for the pyvistaqt tests, but hopefully not too much.