### PR TITLE
Remove Jinja2 pinning again

### DIFF
--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -52,10 +52,6 @@ specs:
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 
-  # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP START ⛔️ ⛔️ ⛔️
-  - jinja2 <3.1,>=2.10  # Remove once https://github.com/conda-forge/numpydoc-feedstock/pull/17 has been merged
-  # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
-
   - mne =1.0.0=*_1
   - mne-installer-menus =1.0.0=*_1
   - mne-qt-browser ~=0.2.6


### PR DESCRIPTION
The numpydoc package on conda-forge has been updated,
so now we shouldn't get into trouble because
of unsatisfiable Jinja2 dependencies again.