### PR TITLE
WIP: Bash entry for windows, normalize names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,7 +217,7 @@ jobs:
 
           echo "Checking we have all .app bundles in /Applications/MNE-Python:"
           ls -d /Applications/MNE-Python/*.app
-          test `ls -d /Applications/MNE-Python/*.app | wc -l` -eq 5
+          test `ls -d /Applications/MNE-Python/*.app | wc -l` -eq 3
 
           echo "Checking that the custom icon was set on the MNE folder in /Applications/MNE-Python"
           test -f /Applications/MNE-Python/Icon$'\r'
@@ -250,7 +250,7 @@ jobs:
           ls -l
           echo "Checking for existence of .desktop files:"
           ls MNE-Python*.desktop
-          test `ls MNE-Python*.desktop | wc -l` -eq 5
+          test `ls MNE-Python*.desktop | wc -l` -eq 3
           echo ""
 
           # … and patched to work around a bug in menuinst
@@ -318,7 +318,7 @@ jobs:
       - name: Export frozen environment definition (Windows)
         if: ${{ runner.os == 'Windows' }}
         run: |
-          $MneRoot = "$env:UserProfile\mne-python\$env:MNE_INSTALLER_VERSION"
+          $MneRoot = "$env:UserProfile\mne-python\${MNE_INSTALLER_VERSION}"
           . "$MneRoot\shell\condabin\conda-hook.ps1"
           conda activate $MneRoot
           mamba list --json > MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.env.json

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -16,16 +16,16 @@ initialize_by_default: False
 register_python_default: False
 
 # default_prefix will be ignored by macOS .pkg installer!
-default_prefix: ${HOME}/mne-python/1.0.0_2                          # [linux]
-default_prefix: "%USERPROFILE%\\mne-python\\1.0.0_2"                # [win]
-default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.0.0_2"   # [win]
-default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.0_2"  # [win]
+default_prefix: ${HOME}/mne-python/1.0.0_1                          # [linux]
+default_prefix: "%USERPROFILE%\\mne-python\\1.0.0_1"                # [win]
+default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.0.0_1"   # [win]
+default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.0_1"  # [win]
 
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
-installer_filename: MNE-Python-1.0.0_2-macOS_Intel.pkg  # [osx]
-installer_filename: MNE-Python-1.0.0_2-Windows.exe      # [win]
-installer_filename: MNE-Python-1.0.0_2-Linux.sh         # [linux]
+installer_filename: MNE-Python-1.0.0_1-macOS_Intel.pkg  # [osx]
+installer_filename: MNE-Python-1.0.0_1-Windows.exe      # [win]
+installer_filename: MNE-Python-1.0.0_1-Linux.sh         # [linux]
 
 post_install: ../../assets/post_install_macOS.sh        # [osx]
 post_install: ../../assets/post_install_linux.sh        # [linux]
@@ -125,4 +125,4 @@ condarc:
     - conda-forge
   channel_priority: strict
   allow_other_channels: False
-  env_prompt: "(mne-1.0.0_2) "
+  env_prompt: "(mne-1.0.0_1) "

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -1,4 +1,4 @@
-version: 1.0.0_1
+version: 1.0.0_2
 name: MNE-Python
 company: MNE-Python Developers
 
@@ -16,16 +16,16 @@ initialize_by_default: False
 register_python_default: False
 
 # default_prefix will be ignored by macOS .pkg installer!
-default_prefix: ${HOME}/mne-python/1.0.0_1                          # [linux]
-default_prefix: "%USERPROFILE%\\mne-python\\1.0.0_1"                # [win]
-default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.0.0_1"   # [win]
-default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.0_1"  # [win]
+default_prefix: ${HOME}/mne-python/1.0.0_2                          # [linux]
+default_prefix: "%USERPROFILE%\\mne-python\\1.0.0_2"                # [win]
+default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.0.0_2"   # [win]
+default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.0_2"  # [win]
 
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
-installer_filename: MNE-Python-1.0.0_1-macOS_Intel.pkg  # [osx]
-installer_filename: MNE-Python-1.0.0_1-Windows.exe      # [win]
-installer_filename: MNE-Python-1.0.0_1-Linux.sh         # [linux]
+installer_filename: MNE-Python-1.0.0_2-macOS_Intel.pkg  # [osx]
+installer_filename: MNE-Python-1.0.0_2-Windows.exe      # [win]
+installer_filename: MNE-Python-1.0.0_2-Linux.sh         # [linux]
 
 post_install: ../../assets/post_install_macOS.sh        # [osx]
 post_install: ../../assets/post_install_linux.sh        # [linux]
@@ -56,8 +56,8 @@ specs:
   - jinja2 <3.1,>=2.10  # Remove once https://github.com/conda-forge/numpydoc-feedstock/pull/17 has been merged
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 
-  - mne =1.0.0=*_1
-  - mne-installer-menus =1.0.0=*_1
+  - mne =1.0.0=*_2
+  - mne-installer-menus =1.0.0=*_2
   - mne-qt-browser ~=0.2.6
   - mne-bids ~=0.10.0
   - mne-connectivity ~=0.3.0
@@ -125,4 +125,4 @@ condarc:
     - conda-forge
   channel_priority: strict
   allow_other_channels: False
-  env_prompt: "(mne-1.0.0_1) "
+  env_prompt: "(mne-1.0.0_2) "


### PR DESCRIPTION
1. it seems like we should use `_post2` rather than `_2` in our names as it's more standard (and it's what we're calling our releases anyway)
2. This uses the `_2` conda builds, so it should include a Bash entry on Windows now.

@hoechenberger if you're happy with this, could you merge and cut a release draft, then you or I could test on Windows? I'd encourage you to try VirtualBox again, the ~20 GB [Windows test VM](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/) worked pretty well for me there in testing!