### PR TITLE
TST: Minimal error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,6 +190,7 @@ jobs:
 
       - name: Check installation (macOS)
         if: ${{ runner.os == 'macOS' }}
+        shell: bash -el {0}
         run: |
           source /Applications/MNE-Python/.mne-python/bin/activate
           conda info
@@ -227,6 +228,7 @@ jobs:
 
       - name: Check installation (Linux)
         if: ${{ runner.os == 'Linux' }}
+        shell: bash -el {0}
         run: |
           sudo apt-get install -y xvfb
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1280x1024x24 -ac +extension GLX +render -noreset -nolisten tcp -nolisten unix


### PR DESCRIPTION
https://github.com/mne-tools/mne-installers/pull/114 shows an error, let's see if we can *really* narrow it down to `bash -e` making a (good) difference to show an existing (bad) error. If it doesn't, it's possible that this is somehow related to the version extraction (?).