### PR TITLE
MAINT: Bump to 1.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,29 @@ jobs:
         run: |
           .\MNE-Python-%MNE_INSTALLER_VERSION%-Windows.exe /S /InstallationType=JustMe /AddToPath=1
 
+      - name: Export frozen environment definition (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          source /Applications/MNE-Python/.mne-python/bin/activate
+          mamba list --json > MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.env.json
+          cat MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.env.json
+
+      - name: Export frozen environment definition (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          source ~/mne-python/${MNE_INSTALLER_VERSION}/bin/activate
+          mamba list --json > MNE-Python-${MNE_INSTALLER_VERSION}-Linux.env.json
+          cat MNE-Python-${MNE_INSTALLER_VERSION}-Linux.env.json
+
+      - name: Export frozen environment definition (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          $MneRoot = "$env:UserProfile\mne-python\$env:MNE_INSTALLER_VERSION"
+          . "$MneRoot\shell\condabin\conda-hook.ps1"
+          conda activate $MneRoot
+          mamba list --json > MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.env.json
+          Get-Content MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.env.json
+
       - name: Check installation (macOS)
         if: ${{ runner.os == 'macOS' }}
         run: |
@@ -303,29 +326,6 @@ jobs:
       #     name: MNE-Python
       #     path: |
       #       MNE-Python-*.*
-
-      - name: Export frozen environment definition (macOS)
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          source /Applications/MNE-Python/.mne-python/bin/activate
-          mamba list --json > MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.env.json
-          cat MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.env.json
-
-      - name: Export frozen environment definition (Linux)
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          source ~/mne-python/${MNE_INSTALLER_VERSION}/bin/activate
-          mamba list --json > MNE-Python-${MNE_INSTALLER_VERSION}-Linux.env.json
-          cat MNE-Python-${MNE_INSTALLER_VERSION}-Linux.env.json
-
-      - name: Export frozen environment definition (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        run: |
-          $MneRoot = "$env:UserProfile\mne-python\$env:MNE_INSTALLER_VERSION"
-          . "$MneRoot\shell\condabin\conda-hook.ps1"
-          conda activate $MneRoot
-          mamba list --json > MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.env.json
-          Get-Content MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.env.json
 
       - name: Release
         if: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,6 +230,7 @@ jobs:
           python tests/test_gui.py
           python tests/test_gui_macosx.py
           python tests/test_notebook.py
+          python tests/test_json_versions.py
 
       - name: Check installation (Linux)
         if: ${{ runner.os == 'Linux' }}
@@ -274,6 +275,7 @@ jobs:
           python tests/test_imports.py
           python tests/test_gui.py
           python tests/test_notebook.py
+          python tests/test_json_versions.py
 
       - name: Check installation (Windows)
         if: ${{ runner.os == 'Windows' }}
@@ -292,6 +294,7 @@ jobs:
           python tests\test_imports.py
           python tests\test_gui.py
           python tests\test_notebook.py
+          python tests/test_json_versions.py
 
       # - name: Archive artifacts
       #   if: ${{ matrix.os == 'ubuntu-18.04' || matrix.os == 'macOS-10.15' || matrix.os == 'windows-2016' }}

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -56,8 +56,8 @@ specs:
   - jinja2 <3.1,>=2.10  # Remove once https://github.com/conda-forge/numpydoc-feedstock/pull/17 has been merged
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 
-  - mne =1.0.1=*_1
-  - mne-installer-menus =1.0.1=*_1
+  - mne =1.0.1=*_0
+  - mne-installer-menus =1.0.1=*_0
   - mne-qt-browser ~=0.3.0
   - mne-bids ~=0.10.0
   - mne-connectivity ~=0.3.0

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -1,4 +1,4 @@
-version: 1.0.1_1
+version: 1.0.2_0
 name: MNE-Python
 company: MNE-Python Developers
 
@@ -16,16 +16,16 @@ initialize_by_default: False
 register_python_default: False
 
 # default_prefix will be ignored by macOS .pkg installer!
-default_prefix: ${HOME}/mne-python/1.0.1_1                          # [linux]
-default_prefix: "%USERPROFILE%\\mne-python\\1.0.1_1"                # [win]
-default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.0.1_1"   # [win]
-default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.1_1"  # [win]
+default_prefix: ${HOME}/mne-python/1.0.2_0                          # [linux]
+default_prefix: "%USERPROFILE%\\mne-python\\1.0.2_0"                # [win]
+default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.0.2_0"   # [win]
+default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.2_0"  # [win]
 
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
-installer_filename: MNE-Python-1.0.1_1-macOS_Intel.pkg  # [osx]
-installer_filename: MNE-Python-1.0.1_1-Windows.exe      # [win]
-installer_filename: MNE-Python-1.0.1_1-Linux.sh         # [linux]
+installer_filename: MNE-Python-1.0.2_0-macOS_Intel.pkg  # [osx]
+installer_filename: MNE-Python-1.0.2_0-Windows.exe      # [win]
+installer_filename: MNE-Python-1.0.2_0-Linux.sh         # [linux]
 
 post_install: ../../assets/post_install_macOS.sh        # [osx]
 post_install: ../../assets/post_install_linux.sh        # [linux]
@@ -125,4 +125,4 @@ condarc:
     - conda-forge
   channel_priority: strict
   allow_other_channels: False
-  env_prompt: "(mne-1.0.1_1) "
+  env_prompt: "(mne-1.0.2_0) "

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -56,8 +56,8 @@ specs:
   - jinja2 <3.1,>=2.10  # Remove once https://github.com/conda-forge/numpydoc-feedstock/pull/17 has been merged
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 
-  - mne =1.0.1=*_0
-  - mne-installer-menus =1.0.1=*_0
+  - mne =1.0.2=*_0
+  - mne-installer-menus =1.0.2=*_0
   - mne-qt-browser ~=0.3.0
   - mne-bids ~=0.10.0
   - mne-connectivity ~=0.3.0

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -56,8 +56,8 @@ specs:
   - jinja2 <3.1,>=2.10  # Remove once https://github.com/conda-forge/numpydoc-feedstock/pull/17 has been merged
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 
-  - mne =1.0.2=*_0
-  - mne-installer-menus =1.0.2=*_0
+  - mne =1.0.1=*_1
+  - mne-installer-menus =1.0.1=*_1
   - mne-qt-browser ~=0.3.0
   - mne-bids ~=0.10.0
   - mne-connectivity ~=0.3.0

--- a/tests/test_json_versions.py
+++ b/tests/test_json_versions.py
@@ -10,7 +10,7 @@ dir_ = pathlib.Path(__file__).parent.parent
 
 sys_name = dict(
     linux='Linux',
-    darwin='macOS',
+    darwin='macOS_Intel',
     win32='Windows',
 )[sys.platform]
 

--- a/tests/test_json_versions.py
+++ b/tests/test_json_versions.py
@@ -1,0 +1,35 @@
+# Read the JSON and YAML and make sure the version + build match
+
+import os
+import sys
+from pathlib import Path
+import json
+import yaml
+
+dir_ = Path(__file__).parent.parent
+
+sys_name = dict(
+    linux='Linux',
+    darwin='macOS',
+    win32='Windows',
+)[sys.platform]
+
+with open(dir_ / 'recipes' / 'mne-python_1.0' / 'construct.yaml') as fid:
+    params = yaml.safe_load(fid)
+want_version = params['version']
+
+fname = dir_ / f'MNE-Python-{want_version}-{sys_name}.env.json'
+assert fname.is_file(), (fname, os.listdir(os.getcwd()))
+with open(fname) as fid:
+    env_json = json.load(fid)
+got_versions = dict()
+for package in env_json:
+    if package['name'] in ('mne', 'mne-installer-menus'):
+        v, b = package['version'], package['build_number']
+        got_versions[package['name']] = f'{v}_{b}'
+assert len(got_versions) == 2, got_versions
+
+# sanitize versions
+for name, version in got_versions.items():
+    msg = f'{name}: got {repr(version)} != want {repr(want_version)}'
+    assert version == want_version, msg

--- a/tests/test_json_versions.py
+++ b/tests/test_json_versions.py
@@ -1,12 +1,12 @@
 # Read the JSON and YAML and make sure the version + build match
 
-import os
-import sys
-from pathlib import Path
 import json
+import os
+import pathlib
+import sys
 import yaml
 
-dir_ = Path(__file__).parent.parent
+dir_ = pathlib.Path(__file__).parent.parent
 
 sys_name = dict(
     linux='Linux',
@@ -29,7 +29,7 @@ for package in env_json:
         got_versions[package['name']] = f'{v}_{b}'
 assert len(got_versions) == 2, got_versions
 
-# sanitize versions
+# check versions
 for name, version in got_versions.items():
     msg = f'{name}: got {repr(version)} != want {repr(want_version)}'
     assert version == want_version, msg

--- a/tests/test_json_versions.py
+++ b/tests/test_json_versions.py
@@ -14,13 +14,14 @@ sys_name = dict(
     win32='Windows',
 )[sys.platform]
 
-with open(dir_ / 'recipes' / 'mne-python_1.0' / 'construct.yaml') as fid:
+with open(dir_ / 'recipes' / 'mne-python_1.0' / 'construct.yaml',
+          encoding='utf-8') as fid:
     params = yaml.safe_load(fid)
 want_version = params['version']
 
 fname = dir_ / f'MNE-Python-{want_version}-{sys_name}.env.json'
 assert fname.is_file(), (fname, os.listdir(os.getcwd()))
-with open(fname) as fid:
+with open(fname, encoding='utf-8') as fid:
     env_json = json.load(fid)
 got_versions = dict()
 for package in env_json:


### PR DESCRIPTION
Will fail until https://github.com/conda-forge/mne-feedstock/pull/93 lands and then hits CDNs later today