### PR TITLE
MAINT: Bump to 1.0.3

### DIFF
--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -1,4 +1,4 @@
-version: 1.0.2_1
+version: 1.0.3_0
 name: MNE-Python
 company: MNE-Python Developers
 
@@ -16,16 +16,16 @@ initialize_by_default: False
 register_python_default: False
 
 # default_prefix will be ignored by macOS .pkg installer!
-default_prefix: ${HOME}/mne-python/1.0.2_1                          # [linux]
-default_prefix: "%USERPROFILE%\\mne-python\\1.0.2_1"                # [win]
-default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.0.2_1"   # [win]
-default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.2_1"  # [win]
+default_prefix: ${HOME}/mne-python/1.0.3_0                          # [linux]
+default_prefix: "%USERPROFILE%\\mne-python\\1.0.3_0"                # [win]
+default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.0.3_0"   # [win]
+default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.3_0"  # [win]
 
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
-installer_filename: MNE-Python-1.0.2_1-macOS_Intel.pkg  # [osx]
-installer_filename: MNE-Python-1.0.2_1-Windows.exe      # [win]
-installer_filename: MNE-Python-1.0.2_1-Linux.sh         # [linux]
+installer_filename: MNE-Python-1.0.3_0-macOS_Intel.pkg  # [osx]
+installer_filename: MNE-Python-1.0.3_0-Windows.exe      # [win]
+installer_filename: MNE-Python-1.0.3_0-Linux.sh         # [linux]
 
 post_install: ../../assets/post_install_macOS.sh        # [osx]
 post_install: ../../assets/post_install_linux.sh        # [linux]
@@ -56,8 +56,8 @@ specs:
   - jinja2 <3.1,>=2.10  # Remove once https://github.com/conda-forge/numpydoc-feedstock/pull/17 has been merged
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 
-  - mne =1.0.2=*_2
-  - mne-installer-menus =1.0.2=*_2
+  - mne =1.0.3=*_0
+  - mne-installer-menus =1.0.3=*_0
   - mne-qt-browser ~=0.3.0
   - mne-bids ~=0.10.0
   - mne-connectivity ~=0.3.0
@@ -127,4 +127,4 @@ condarc:
     - conda-forge
   channel_priority: strict
   allow_other_channels: False
-  env_prompt: "(mne-1.0.2_1) "
+  env_prompt: "(mne-1.0.3_0) "


### PR DESCRIPTION
@hoechenberger I should be able to do this today:

- [x] https://github.com/conda-forge/mne-feedstock/pull/96 (automerge)
- [x] Wait for CDN update and restart CIs here to get green
- [x] merge
- [ ] cut a release here
- [ ] update https://github.com/mne-tools/mne-python/pull/10622
- [ ] backport instruction update with `[circle deploy]`