### PR TITLE
ENH: Build for M1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # Based on https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
       - name: Install code-signing certificates (macOS)
-        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' && matrix.arch == 'native'}}
+        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
         env:
           APPLICATION_CERT_BASE64: ${{ secrets.APPLE_APPLICATION_CERT_BASE64 }}
           APPLICATION_CERT_PASSWORD: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,12 +121,12 @@ jobs:
         if: ${{ matrix.arch == 'arm64' }}
         shell: bash -el {0}
         run: |
-          conda install -c napari/label/bundle_tools conda-standalone
-          echo "PLATFORM_ARG=\"--platform=osx-arm64\"" >> $GITHUB_ENV
-          echo "EXE_ARG=\"--conda-exe=${CONDA_PREFIX}/standalone_conda/conda.exe\"" >> $GITHUB_ENV
+          source ./tools/setup_m1_crosscompile.sh
+          echo "EXE_ARG=${EXE_ARG}" >> $GITHUB_ENV
+          echo "PLATFORM_ARG=${PLATFORM_ARG}" >> $GITHUB_ENV
 
       - name: Patch config (macOS pull request)
-        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' && matrix.arch == 'native' }}
+        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
         shell: bash -el {0}
         run: |
           sed -i "" "s/_name: *# \[osx\]/_name: 9779L28NP8  # \[osx\]/" ${RECIPE_DIR}/construct.yaml
@@ -185,13 +185,25 @@ jobs:
           Get-FileHash MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.exe -Algorithm SHA256 > MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.exe.sha256.txt
           Get-Content MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.exe.sha256.txt
 
-      - name: Run installer (macOS)
-        if: ${{ runner.os == 'macOS' && matrix.arch == 'native' }}
+      - name: Check installer (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           echo `pwd`
-          installer -verbose -pkginfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.pkg
-          installer -verbose -dominfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.pkg
-          installer -verbose -volinfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.pkg
+          if [[ ${ARCH} == 'native' ]]; then
+            MACOS_SUFFIX="Intel"
+          else
+            MACOS_SUFFIX="ARM"
+          fi
+          echo "MACOS_SUFFIX=${MACOS_SUFFIX}" >> $GITHUB_ENV
+          installer -verbose -pkginfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_{MACOS_SUFFIX}.pkg
+          installer -verbose -dominfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_{MACOS_SUFFIX}.pkg
+          installer -verbose -volinfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_{MACOS_SUFFIX}.pkg
+
+      - name: Run installer (macOS Intel)
+        if: ${{ runner.os == 'macOS' && matrix.arch == 'native' }}
+        run: |
           sudo installer \
             -verbose \
             -pkg MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.pkg \
@@ -211,7 +223,7 @@ jobs:
         run: |
           .\MNE-Python-%MNE_INSTALLER_VERSION%-Windows.exe /S /InstallationType=JustMe /AddToPath=1
 
-      - name: Export frozen environment definition (macOS)
+      - name: Export frozen environment definition (macOS Intel)
         if: ${{ runner.os == 'macOS' && matrix.arch == 'native' }}
         run: |
           source /Applications/MNE-Python/.mne-python/bin/activate
@@ -234,7 +246,7 @@ jobs:
           mamba list --json > MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.env.json
           Get-Content MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.env.json
 
-      - name: Check installation (macOS)
+      - name: Check installation (macOS Intel)
         if: ${{ runner.os == 'macOS' && matrix.arch == 'native' }}
         run: |
           source /Applications/MNE-Python/.mne-python/bin/activate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,9 +197,9 @@ jobs:
             MACOS_SUFFIX="ARM"
           fi
           echo "MACOS_SUFFIX=${MACOS_SUFFIX}" >> $GITHUB_ENV
-          installer -verbose -pkginfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_{MACOS_SUFFIX}.pkg
-          installer -verbose -dominfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_{MACOS_SUFFIX}.pkg
-          installer -verbose -volinfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_{MACOS_SUFFIX}.pkg
+          installer -verbose -pkginfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_${MACOS_SUFFIX}.pkg
+          installer -verbose -dominfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_${MACOS_SUFFIX}.pkg
+          installer -verbose -volinfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_${MACOS_SUFFIX}.pkg
 
       - name: Run installer (macOS Intel)
         if: ${{ runner.os == 'macOS' && matrix.arch == 'native' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
           .\MNE-Python-%MNE_INSTALLER_VERSION%-Windows.exe /S /InstallationType=JustMe /AddToPath=1
 
       - name: Export frozen environment definition (macOS)
-        if: ${{ runner.os == 'macOS' and matrix.arch == 'native' }}
+        if: ${{ runner.os == 'macOS' && matrix.arch == 'native' }}
         run: |
           source /Applications/MNE-Python/.mne-python/bin/activate
           mamba list --json > MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.env.json
@@ -235,7 +235,7 @@ jobs:
           Get-Content MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.env.json
 
       - name: Check installation (macOS)
-        if: ${{ runner.os == 'macOS' and matrix.arch == 'native' }}
+        if: ${{ runner.os == 'macOS' && matrix.arch == 'native' }}
         run: |
           source /Applications/MNE-Python/.mne-python/bin/activate
           conda info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11, windows-2019, windows-2022]
         arch: [native]
         include:
-          - os: [macos-11]
-            arch: [arm64]
+          - os: macos-11
+            arch: arm64
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           ./tools/patch_constructor.sh
 
-      - name: Add macOS M1 (ARM) support
+      - name: Add macOS M1 support
         if: ${{ matrix.arch == 'arm64' }}
         shell: bash -el {0}
         run: |
@@ -194,7 +194,7 @@ jobs:
           if [[ ${ARCH} == 'native' ]]; then
             MACOS_SUFFIX="Intel"
           else
-            MACOS_SUFFIX="ARM"
+            MACOS_SUFFIX="M1"
           fi
           echo "MACOS_SUFFIX=${MACOS_SUFFIX}" >> $GITHUB_ENV
           installer -verbose -pkginfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_${MACOS_SUFFIX}.pkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
           Get-Content MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.exe.sha256.txt
 
       - name: Run installer (macOS)
-        if: ${{ runner.os == 'macOS' and matrix.arch == 'native' }}
+        if: ${{ runner.os == 'macOS' && matrix.arch == 'native' }}
         run: |
           echo `pwd`
           installer -verbose -pkginfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.pkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           ./tools/run_constructor.sh
 
       - name: Check installer signature (macOS)
-        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request'}}
+        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' && matrix.arch == 'native' }}
         run: |
           # Installer package
           pkgutil --check-signature MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.pkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           ./tools/run_constructor.sh
 
       - name: Check installer signature (macOS)
-        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' && matrix.arch == 'native' }}
+        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
         run: |
           # Installer package
           pkgutil --check-signature MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.pkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11, windows-2019, windows-2022]
+        arch: [native]
+        include:
+          - os: [macos-11]
+            arch: [arm64]
 
     runs-on: ${{ matrix.os }}
 
@@ -28,7 +32,7 @@ jobs:
     steps:
       # Based on https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
       - name: Install code-signing certificates (macOS)
-        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
+        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' && matrix.arch == 'native'}}
         env:
           APPLICATION_CERT_BASE64: ${{ secrets.APPLE_APPLICATION_CERT_BASE64 }}
           APPLICATION_CERT_PASSWORD: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}
@@ -113,8 +117,16 @@ jobs:
         run: |
           ./tools/patch_constructor.sh
 
+      - name: Add macOS M1 (ARM) support
+        if: ${{ matrix.arch == 'arm64' }}
+        shell: bash -el {0}
+        run: |
+          conda install -c napari/label/bundle_tools conda-standalone
+          echo "PLATFORM_ARG=\"--platform=osx-arm64\"" >> $GITHUB_ENV
+          echo "EXE_ARG=\"--conda-exe=${CONDA_PREFIX}/standalone_conda/conda.exe\"" >> $GITHUB_ENV
+
       - name: Patch config (macOS pull request)
-        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
+        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' && matrix.arch == 'native' }}
         shell: bash -el {0}
         run: |
           sed -i "" "s/_name: *# \[osx\]/_name: 9779L28NP8  # \[osx\]/" ${RECIPE_DIR}/construct.yaml
@@ -129,7 +141,7 @@ jobs:
           ./tools/run_constructor.sh
 
       - name: Check installer signature (macOS)
-        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
+        if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request'}}
         run: |
           # Installer package
           pkgutil --check-signature MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.pkg
@@ -174,7 +186,7 @@ jobs:
           Get-Content MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.exe.sha256.txt
 
       - name: Run installer (macOS)
-        if: ${{ runner.os == 'macOS' }}
+        if: ${{ runner.os == 'macOS' and matrix.arch == 'native' }}
         run: |
           echo `pwd`
           installer -verbose -pkginfo -pkg ./MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.pkg
@@ -200,7 +212,7 @@ jobs:
           .\MNE-Python-%MNE_INSTALLER_VERSION%-Windows.exe /S /InstallationType=JustMe /AddToPath=1
 
       - name: Export frozen environment definition (macOS)
-        if: ${{ runner.os == 'macOS' }}
+        if: ${{ runner.os == 'macOS' and matrix.arch == 'native' }}
         run: |
           source /Applications/MNE-Python/.mne-python/bin/activate
           mamba list --json > MNE-Python-${MNE_INSTALLER_VERSION}-macOS_Intel.env.json
@@ -223,7 +235,7 @@ jobs:
           Get-Content MNE-Python-$env:MNE_INSTALLER_VERSION-Windows.env.json
 
       - name: Check installation (macOS)
-        if: ${{ runner.os == 'macOS' }}
+        if: ${{ runner.os == 'macOS' and matrix.arch == 'native' }}
         run: |
           source /Applications/MNE-Python/.mne-python/bin/activate
           conda info

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Locally, installers can be built using `tools/build_local.sh`. Steps:
    $ conda env create -f environment.yml
    $ conda activate constructor-env
    ```
-2. Run `./tools/build_local.sh` (which will patch the constructor on macOS if needed)
-3. Install the environment for your platform
-4. Test it using the `tests/`
+2. If you want to build an arm64 (M1) package on a macOS Intel machine, run `source ./tools/setup_m1_crosscompile.sh`.
+3. Run `./tools/build_local.sh` (which will patch the constructor on macOS if needed).
+4. Install the environment for your platform.
+5. Test it using the `tests/`.

--- a/assets/constructor_macOS.patch
+++ b/assets/constructor_macOS.patch
@@ -53,7 +53,7 @@ diff -Naur constructor-orig/osxpkg.py constructor-patched/osxpkg.py
      root.append(title)
 
      license = ET.Element('license', file=info.get('license_file',
-@@ -153,8 +153,11 @@
+@@ -153,8 +153,9 @@
      # See below for an explanation of the consequences of this
      # customLocation value.
      for options in root.findall('options'):
@@ -62,8 +62,6 @@ diff -Naur constructor-orig/osxpkg.py constructor-patched/osxpkg.py
 +        options.set('customize', 'never')
 +        options.set('customLocation', '/Applications/MNE-Python')
 +        options.set('rootVolumeOnly', 'true')
-+        # Force to run installer through Rosetta 2 on Apple Silicon
-+        options.set('hostArchitectures', 'x86_64')
 
      # By default, the package builder puts all of our options under
      # a single master choice. This deletes that master choice and

--- a/assets/constructor_macOS.patch
+++ b/assets/constructor_macOS.patch
@@ -53,7 +53,7 @@ diff -Naur constructor-orig/osxpkg.py constructor-patched/osxpkg.py
      root.append(title)
 
      license = ET.Element('license', file=info.get('license_file',
-@@ -153,8 +153,9 @@
+@@ -153,8 +153,11 @@
      # See below for an explanation of the consequences of this
      # customLocation value.
      for options in root.findall('options'):
@@ -62,6 +62,8 @@ diff -Naur constructor-orig/osxpkg.py constructor-patched/osxpkg.py
 +        options.set('customize', 'never')
 +        options.set('customLocation', '/Applications/MNE-Python')
 +        options.set('rootVolumeOnly', 'true')
++        # Force to run installer through Rosetta 2 on Apple Silicon
++        options.set('hostArchitectures', 'x86_64')
 
      # By default, the package builder puts all of our options under
      # a single master choice. This deletes that master choice and

--- a/assets/constructor_macOS_arm64.patch
+++ b/assets/constructor_macOS_arm64.patch
@@ -1,0 +1,12 @@
+diff -Naur constructor-orig/osxpkg.py constructor-patched/osxpkg.py
+--- constructor-orig/osxpkg.py	2022-06-02 23:30:08.000000000 +0200
++++ constructor-patched/osxpkg-patched.py	2022-06-02 23:31:41.000000000 +0200
+@@ -156,6 +156,8 @@
+         options.set('customize', 'never')
+         options.set('customLocation', '/Applications/MNE-Python')
+         options.set('rootVolumeOnly', 'true')
++        # Be explicit and declare we're only able to work on Apple Silicon
++        options.set('hostArchitectures', 'arm64')
+
+     # By default, the package builder puts all of our options under
+     # a single master choice. This deletes that master choice and

--- a/assets/constructor_macOS_common.patch
+++ b/assets/constructor_macOS_common.patch
@@ -53,7 +53,7 @@ diff -Naur constructor-orig/osxpkg.py constructor-patched/osxpkg.py
      root.append(title)
 
      license = ET.Element('license', file=info.get('license_file',
-@@ -153,8 +153,11 @@
+@@ -153,8 +153,9 @@
      # See below for an explanation of the consequences of this
      # customLocation value.
      for options in root.findall('options'):
@@ -62,8 +62,6 @@ diff -Naur constructor-orig/osxpkg.py constructor-patched/osxpkg.py
 +        options.set('customize', 'never')
 +        options.set('customLocation', '/Applications/MNE-Python')
 +        options.set('rootVolumeOnly', 'true')
-+        # Force to run installer through Rosetta 2 on Apple Silicon
-+        options.set('hostArchitectures', 'x86_64')
 
      # By default, the package builder puts all of our options under
      # a single master choice. This deletes that master choice and

--- a/assets/constructor_macOS_i386.patch
+++ b/assets/constructor_macOS_i386.patch
@@ -1,0 +1,12 @@
+diff -Naur constructor-orig/osxpkg.py constructor-patched/osxpkg.py
+--- constructor-orig/osxpkg.py	2022-06-02 23:30:08.000000000 +0200
++++ constructor-patched/osxpkg-patched.py	2022-06-02 23:31:41.000000000 +0200
+@@ -156,6 +156,8 @@
+         options.set('customize', 'never')
+         options.set('customLocation', '/Applications/MNE-Python')
+         options.set('rootVolumeOnly', 'true')
++        # Force to run installer through Rosetta 2 on Apple Silicon
++        options.set('hostArchitectures', 'x86_64')
+
+     # By default, the package builder puts all of our options under
+     # a single master choice. This deletes that master choice and

--- a/assets/post_install_macOS.sh
+++ b/assets/post_install_macOS.sh
@@ -33,7 +33,7 @@ osascript \
 # Use Intel packages if the Python binary is x84_64, i.e. not native Apple Silicon
 # (This also applies to an Intel binary running on Apple Silicon through Rosetta)
 # https://conda-forge.org/docs/user/tipsandtricks.html#installing-apple-intel-packages-on-apple-silicon
-export PYTHON_PLATFORM=`${DSTROOT}/.mne-python/bin/conda run python -c "import platform; print(platform.machine())`
+export PYTHON_PLATFORM=`${DSTROOT}/.mne-python/bin/conda run python -c "import platform; print(platform.machine())"`
 if [ "${PYTHON_PLATFORM}" == "x86_64" ]; then
     logger -p 'install.info' "ℹ️ Configuring conda to only use Intel packages"
     ${DSTROOT}/.mne-python/bin/conda env config vars set CONDA_SUBDIR=osx-64
@@ -42,7 +42,7 @@ fi
 logger -p 'install.info' "ℹ️ Configuring Python to ignore user-installed local packages"
 ${DSTROOT}/.mne-python/bin/conda env config vars set PYTHONNOUSERSITE=1
 
-logger -p 'install.info' "ℹ️ Disable mamba package manager banner"
+logger -p 'install.info' "ℹ️ Disabling mamba package manager banner"
 ${DSTROOT}/.mne-python/bin/conda env config vars set MAMBA_NO_BANNER=1
 
 logger -p 'install.info' "Fixing permissions of entire conda environment"

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -54,6 +54,10 @@ specs:
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 
+  # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP START ⛔️ ⛔️ ⛔️
+  - jinja2 <3.1,>=2.10  # Remove once https://github.com/conda-forge/numpydoc-feedstock/pull/17 has been merged
+  # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
+
   - mne =1.0.3=*_0
   - mne-installer-menus =1.0.3=*_0  # [not arm64]
   - mne-qt-browser ~=0.3.0

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -25,7 +25,8 @@ default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.3_0"  # [win]
 
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
-installer_filename: MNE-Python-1.0.3_0-macOS_Intel.pkg  # [osx]
+installer_filename: MNE-Python-1.0.3_0-macOS_Intel.pkg  # [osx and not arm64]
+installer_filename: MNE-Python-1.0.3_0-macOS_ARM.pkg  # [osx and arm64]
 installer_filename: MNE-Python-1.0.3_0-Windows.exe      # [win]
 installer_filename: MNE-Python-1.0.3_0-Linux.sh         # [linux]
 
@@ -59,7 +60,7 @@ specs:
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 
   - mne =1.0.3=*_0
-  - mne-installer-menus =1.0.3=*_0  # [not arm64]
+  - mne-installer-menus =1.0.3=*_0
   - mne-qt-browser ~=0.3.0
   - mne-bids ~=0.10.0
   - mne-connectivity ~=0.3.0

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -71,7 +71,7 @@ specs:
   - mne-rsa ~=0.6.0
   - mne-microstates ~=0.3.0
   - mne-ari ~=0.1.0
-  - mne-kit-gui ~=1.0.1  # [not arm64]
+  - mne-kit-gui ~=1.0.1
   - mne-icalabel ~=0.1.0  # [not win]
   - autoreject ~=0.3.1
   - pyprep ~=0.4.0

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -10,9 +10,9 @@ welcome_image: ../../assets/welcome_macOS.png  # [osx]
 welcome_image: ../../assets/welcome.png        # [not osx]
 header_image: ../../assets/header.png
 icon_image: ../../assets/icon.png
-welcome_file: ../../assets/welcome.rtf
-readme_text: ""
-conclusion_file: ../../assets/conclusion.rtf
+#welcome_file: ../../assets/welcome.rtf
+#readme_text: ""
+#conclusion_file: ../../assets/conclusion.rtf
 
 initialize_by_default: False
 register_python_default: False
@@ -37,7 +37,7 @@ post_install: ../../assets/post_install_windows.bat     # [win]
 installer_type: pkg                     # [osx]
 signing_identity_name:                  # [osx]  Used for productsign
 notarization_identity_name:             # [osx]  Used for codesign
-reverse_domain_identifier: tools.mne    # [osx]  Used for productbuild --identifier $reverse_domain_identifier.$name
+#reverse_domain_identifier: tools.mne    # [osx]  Used for productbuild --identifier $reverse_domain_identifier.$name
 
 # Only create menus for mne-installer-menus
 menu_packages:
@@ -59,7 +59,7 @@ specs:
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 
   - mne =1.0.3=*_0
-  - mne-installer-menus =1.0.3=*_0
+  - mne-installer-menus =1.0.3=*_0  # [not arm64]
   - mne-qt-browser ~=0.3.0
   - mne-bids ~=0.10.0
   - mne-connectivity ~=0.3.0
@@ -70,8 +70,8 @@ specs:
   - mne-rsa ~=0.6.0
   - mne-microstates ~=0.3.0
   - mne-ari ~=0.1.0
-  - mne-kit-gui ~=1.0.1
-  - mne-icalabel ~=0.1.0  # [not win]
+  - mne-kit-gui ~=1.0.1  # [not arm64]
+  - mne-icalabel ~=0.1.0
   - autoreject ~=0.3.1
   - pyprep ~=0.4.0
   # Python
@@ -95,7 +95,7 @@ specs:
   - pingouin
   - pycircstat
   # MRI
-  - fsleyes
+  - fsleyes  # [not arm64]
   - dcm2niix  # [not arm64]
   # Time-frequency analysis
   - pactools

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -26,7 +26,7 @@ default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.3_0"  # [win]
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
 installer_filename: MNE-Python-1.0.3_0-macOS_Intel.pkg  # [osx and not arm64]
-installer_filename: MNE-Python-1.0.3_0-macOS_ARM.pkg  # [osx and arm64]
+installer_filename: MNE-Python-1.0.3_0-macOS_ARM.pkg    # [osx and arm64]
 installer_filename: MNE-Python-1.0.3_0-Windows.exe      # [win]
 installer_filename: MNE-Python-1.0.3_0-Linux.sh         # [linux]
 

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -84,7 +84,7 @@ specs:
   - ipykernel
   - nb_conda_kernels
   - spyder-kernels
-  - spyder
+  - spyder  # [not arm64]
   - ipympl
   - darkdetect
   - qdarkstyle
@@ -96,7 +96,7 @@ specs:
   - pycircstat
   # MRI
   - fsleyes
-  - dcm2niix
+  - dcm2niix  # [not arm64]
   # Time-frequency analysis
   - pactools
   - tensorpac
@@ -115,7 +115,7 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py
   # sleep staging
-  - sleepecg
+  - sleepecg  # [not arm64]
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2
   # GitHub client, https://cli.github.com

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -97,7 +97,7 @@ specs:
   - pycircstat
   # MRI
   - fsleyes  # [not arm64]
-  - dcm2niix  # [not arm64]
+  - dcm2niix
   # Time-frequency analysis
   - pactools
   - tensorpac

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -26,7 +26,7 @@ default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.3_0"  # [win]
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
 installer_filename: MNE-Python-1.0.3_0-macOS_Intel.pkg  # [osx and not arm64]
-installer_filename: MNE-Python-1.0.3_0-macOS_M1.pkg    # [osx and arm64]
+installer_filename: MNE-Python-1.0.3_0-macOS_M1.pkg     # [osx and arm64]
 installer_filename: MNE-Python-1.0.3_0-Windows.exe      # [win]
 installer_filename: MNE-Python-1.0.3_0-Linux.sh         # [linux]
 

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -10,9 +10,9 @@ welcome_image: ../../assets/welcome_macOS.png  # [osx]
 welcome_image: ../../assets/welcome.png        # [not osx]
 header_image: ../../assets/header.png
 icon_image: ../../assets/icon.png
-#welcome_file: ../../assets/welcome.rtf
-#readme_text: ""
-#conclusion_file: ../../assets/conclusion.rtf
+welcome_file: ../../assets/welcome.rtf
+readme_text: ""
+conclusion_file: ../../assets/conclusion.rtf
 
 initialize_by_default: False
 register_python_default: False
@@ -37,7 +37,7 @@ post_install: ../../assets/post_install_windows.bat     # [win]
 installer_type: pkg                     # [osx]
 signing_identity_name:                  # [osx]  Used for productsign
 notarization_identity_name:             # [osx]  Used for codesign
-#reverse_domain_identifier: tools.mne    # [osx]  Used for productbuild --identifier $reverse_domain_identifier.$name
+reverse_domain_identifier: tools.mne    # [osx]  Used for productbuild --identifier $reverse_domain_identifier.$name
 
 # Only create menus for mne-installer-menus
 menu_packages:

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -57,6 +57,7 @@ specs:
 
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP START ⛔️ ⛔️ ⛔️
   - jinja2 <3.1,>=2.10  # Remove once https://github.com/conda-forge/numpydoc-feedstock/pull/17 has been merged
+  - docutils <=0.18.0  # Remove once everyone is Sphinx 5 compatible
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 
   - mne =1.0.3=*_1

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -57,7 +57,7 @@ specs:
 
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP START ⛔️ ⛔️ ⛔️
   - jinja2 <3.1,>=2.10  # Remove once https://github.com/conda-forge/numpydoc-feedstock/pull/17 has been merged
-  - docutils <=0.18.0  # Remove once everyone is Sphinx 5 compatible
+  - docutils <=0.17.0  # Remove once everyone is Sphinx 5 compatible (esp. emd->sphinx-rtd-theme)
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 
   - mne =1.0.3=*_1

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -26,7 +26,7 @@ default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.3_0"  # [win]
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
 installer_filename: MNE-Python-1.0.3_0-macOS_Intel.pkg  # [osx and not arm64]
-installer_filename: MNE-Python-1.0.3_0-macOS_M1.pkg     # [osx and arm64]
+installer_filename: MNE-Python-1.0.3_0-macOS_ARM.pkg    # [osx and arm64]
 installer_filename: MNE-Python-1.0.3_0-Windows.exe      # [win]
 installer_filename: MNE-Python-1.0.3_0-Linux.sh         # [linux]
 
@@ -96,7 +96,7 @@ specs:
   - pingouin
   - pycircstat
   # MRI
-  - fsleyes  # [not arm64]
+  - fsleyes
   - dcm2niix
   # Time-frequency analysis
   - pactools
@@ -116,7 +116,7 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py
   # sleep staging
-  - sleepecg  # [not arm64]
+  - sleepecg
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2
   # GitHub client, https://cli.github.com

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -56,7 +56,6 @@ specs:
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP START ⛔️ ⛔️ ⛔️
-  - docutils <=0.17.0  # Remove once everyone is Sphinx 5 compatible (esp. emd->sphinx-rtd-theme)
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 
   - mne =1.0.3=*_1

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -85,7 +85,7 @@ specs:
   - ipykernel
   - nb_conda_kernels
   - spyder-kernels
-  - spyder  # [not arm64]
+  - spyder
   - ipympl
   - darkdetect
   - qdarkstyle

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -26,7 +26,7 @@ default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.0.3_0"  # [win]
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
 installer_filename: MNE-Python-1.0.3_0-macOS_Intel.pkg  # [osx and not arm64]
-installer_filename: MNE-Python-1.0.3_0-macOS_ARM.pkg    # [osx and arm64]
+installer_filename: MNE-Python-1.0.3_0-macOS_M1.pkg    # [osx and arm64]
 installer_filename: MNE-Python-1.0.3_0-Windows.exe      # [win]
 installer_filename: MNE-Python-1.0.3_0-Linux.sh         # [linux]
 

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -59,8 +59,8 @@ specs:
   - jinja2 <3.1,>=2.10  # Remove once https://github.com/conda-forge/numpydoc-feedstock/pull/17 has been merged
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 
-  - mne =1.0.3=*_0
-  - mne-installer-menus =1.0.3=*_0
+  - mne =1.0.3=*_1
+  - mne-installer-menus =1.0.3=*_1
   - mne-qt-browser ~=0.3.0
   - mne-bids ~=0.10.0
   - mne-connectivity ~=0.3.0

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -71,7 +71,7 @@ specs:
   - mne-microstates ~=0.3.0
   - mne-ari ~=0.1.0
   - mne-kit-gui ~=1.0.1  # [not arm64]
-  - mne-icalabel ~=0.1.0
+  - mne-icalabel ~=0.1.0  # [not win]
   - autoreject ~=0.3.1
   - pyprep ~=0.4.0
   # Python

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -56,7 +56,6 @@ specs:
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP START ⛔️ ⛔️ ⛔️
-  - jinja2 <3.1,>=2.10  # Remove once https://github.com/conda-forge/numpydoc-feedstock/pull/17 has been merged
   - docutils <=0.17.0  # Remove once everyone is Sphinx 5 compatible (esp. emd->sphinx-rtd-theme)
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 

--- a/recipes/mne-python_1.0/construct.yaml
+++ b/recipes/mne-python_1.0/construct.yaml
@@ -54,10 +54,6 @@ specs:
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 
-  # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP START ⛔️ ⛔️ ⛔️
-  - jinja2 <3.1,>=2.10  # Remove once https://github.com/conda-forge/numpydoc-feedstock/pull/17 has been merged
-  # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
-
   - mne =1.0.3=*_0
   - mne-installer-menus =1.0.3=*_0  # [not arm64]
   - mne-qt-browser ~=0.3.0

--- a/tools/build_local.sh
+++ b/tools/build_local.sh
@@ -8,5 +8,5 @@ echo "Version:      ${MNE_INSTALLER_VERSION}"
 echo "Recipe:       ${RECIPE_DIR}"
 echo "OS:           ${MACHINE}"
 echo "Architecture: ${PYARCH}"
-${SCRIPT_DIR}/patch_constructor.sh
+#${SCRIPT_DIR}/patch_constructor.sh
 ${SCRIPT_DIR}/run_constructor.sh

--- a/tools/build_local.sh
+++ b/tools/build_local.sh
@@ -8,5 +8,5 @@ echo "Version:      ${MNE_INSTALLER_VERSION}"
 echo "Recipe:       ${RECIPE_DIR}"
 echo "OS:           ${MACHINE}"
 echo "Architecture: ${PYARCH}"
-#${SCRIPT_DIR}/patch_constructor.sh
+${SCRIPT_DIR}/patch_constructor.sh
 ${SCRIPT_DIR}/run_constructor.sh

--- a/tools/build_local.sh
+++ b/tools/build_local.sh
@@ -7,6 +7,8 @@ echo "--------------------------"
 echo "Version:      ${MNE_INSTALLER_VERSION}"
 echo "Recipe:       ${RECIPE_DIR}"
 echo "OS:           ${MACHINE}"
-echo "Architecture: ${PYARCH}"
+echo "Machine:      ${PYMACHINE}"
+echo "PLATFORM_ARG: ${PLATFORM_ARG}"
+echo "EXE_ARG:      ${EXE_ARG}"
 ${SCRIPT_DIR}/patch_constructor.sh
 ${SCRIPT_DIR}/run_constructor.sh

--- a/tools/extract_version.sh
+++ b/tools/extract_version.sh
@@ -18,4 +18,4 @@ if [[ "$MACHINE" != "macOS" && "$MACHINE" != "Linux" && "$MACHINE" != "Windows" 
     exit 1
 fi
 export MACHINE=$MACHINE
-export PYARCH=$(python -c "import platform; print(platform.architecture()[0])")
+export PYMACHINE=$(python -c "import platform; print(platform.machine())")

--- a/tools/patch_constructor.sh
+++ b/tools/patch_constructor.sh
@@ -13,9 +13,11 @@ if [[ $MACHINE == "macOS" ]]; then
         echo "Patching constructor ${CONSTRUCTOR_DIR}..."
         patch -Nd ${CONSTRUCTOR_DIR} -p1 < $PATCHFILE_COMMON
 
-        if [[ $PYMACHINE != "arm64" ]]; then
+        if [[ $PYMACHINE == "arm64" ]]; then
+            echo "Patching for ARM64"
             patch -Nd ${CONSTRUCTOR_DIR} -p1 < $PATCHFILE_ARM64
         else
+            echo "Patching for Intel"
             patch -Nd ${CONSTRUCTOR_DIR} -p1 < $PATCHFILE_I386
         fi
     else

--- a/tools/patch_constructor.sh
+++ b/tools/patch_constructor.sh
@@ -2,14 +2,22 @@
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 source ${SCRIPT_DIR}/extract_version.sh
-# TODO: Once the forked conda constructor is available on mac-arm64 natively,
-# we should remove the second part of this conditional
-if [[ $MACHINE == "macOS" && $PYMACHINE != "arm64" ]]; then
+
+if [[ $MACHINE == "macOS" ]]; then
     CONSTRUCTOR_DIR=${CONDA_PREFIX}/lib/python${PYSHORT}/site-packages/constructor
-    PATCHFILE=${SCRIPT_DIR}/../assets/constructor_macOS.patch
-    if ! patch -Rd ${CONSTRUCTOR_DIR} -p1 -s -f --dry-run < $PATCHFILE; then
+    PATCHFILE_COMMON=${SCRIPT_DIR}/../assets/constructor_macOS_common.patch
+    PATCHFILE_I386=${SCRIPT_DIR}/../assets/constructor_macOS_i386.patch
+    PATCHFILE_ARM64=${SCRIPT_DIR}/../assets/constructor_macOS_arm64.patch
+
+    if ! patch -Rd ${CONSTRUCTOR_DIR} -p1 -s -f --dry-run < $PATCHFILE_COMMON; then
         echo "Patching constructor ${CONSTRUCTOR_DIR}..."
-        patch -Nd ${CONSTRUCTOR_DIR} -p1 < $PATCHFILE
+        patch -Nd ${CONSTRUCTOR_DIR} -p1 < $PATCHFILE_COMMON
+
+        if [[ $PYMACHINE != "arm64" ]]; then
+            patch -Nd ${CONSTRUCTOR_DIR} -p1 < $PATCHFILE_ARM64
+        else
+            patch -Nd ${CONSTRUCTOR_DIR} -p1 < $PATCHFILE_I386
+        fi
     else
         echo "Constructor already patched: ${CONSTRUCTOR_DIR}"
     fi

--- a/tools/patch_constructor.sh
+++ b/tools/patch_constructor.sh
@@ -2,7 +2,9 @@
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 source ${SCRIPT_DIR}/extract_version.sh
-if [[ $MACHINE == "macOS" ]]; then
+# TODO: Once the forked conda constructor is available on mac-arm64 natively,
+# we should remove the second part of this conditional
+if [[ $MACHINE == "macOS" && $PYMACHINE != "arm64" ]]; then
     CONSTRUCTOR_DIR=${CONDA_PREFIX}/lib/python${PYSHORT}/site-packages/constructor
     PATCHFILE=${SCRIPT_DIR}/../assets/constructor_macOS.patch
     if ! patch -Rd ${CONSTRUCTOR_DIR} -p1 -s -f --dry-run < $PATCHFILE; then

--- a/tools/run_constructor.sh
+++ b/tools/run_constructor.sh
@@ -5,4 +5,5 @@ source ${SCRIPT_DIR}/extract_version.sh
 export PYTHONUTF8=1
 # enforce UTF-8 encoding when reading files even on Windows
 echo "Running constructor recipe ${RECIPE_DIR}"
-constructor ${RECIPE_DIR}
+# PLATFORM_ARG and EXE_ARG can be used for building macOS ARM64 on Intel
+constructor ${PLATFORM_ARG} ${EXE_ARG} ${RECIPE_DIR}

--- a/tools/setup_m1_crosscompile.sh
+++ b/tools/setup_m1_crosscompile.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -ef
+
+if ! conda list conda-standalone | grep conda-standalone; then
+    echo "Installing standalone"
+    conda install -yc napari/label/bundle_tools conda-standalone
+fi
+export PLATFORM_ARG="--platform=osx-arm64"
+export EXE_ARG="--conda-exe=${CONDA_PREFIX}/standalone_conda/conda.exe"


### PR DESCRIPTION
- [x] Add suggested path for building macos-arm64 on Intel
- [x] Add CI job
- [x] Fix `_Intel.pkg` naming
- [x] Ensure it's packaged properly (add some basic tests)
- [x] Get CI job green
- [x] Remove `[not arm64]` selectors once they're available

cc @hoechenberger currently I get conflicts when I try this locally on macOS Intel with the following on this branch (which passes the _ARG to run_installers.sh:
```console
$ source ./tools/setup_m1_crosscompile.sh
$ ./tools/run_installers.sh
```
Feel free to try it. I'm going to try doing a native run on my M1 machine with these `[not arm64]` selectors as well.

Closes #48