### PR TITLE
During automated testing, don't require system-wide installed XCB libraries anymore on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build the installers
+name: Build & test
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,7 +328,6 @@ jobs:
       - name: Setup graphical support (Linux)
         if: ${{ runner.os == 'Linux' }}
         run: |
-          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils  # (temporary?) resolution for https://github.com/conda-forge/qt-main-feedstock/issues/32
           sudo apt-get install -y xvfb
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1280x1024x24 -ac +extension GLX +render -noreset -nolisten tcp -nolisten unix
           export DISPLAY=":99"


### PR DESCRIPTION
Now that https://github.com/conda-forge/qt-main-feedstock/pull/39 has been resolved