### PR TITLE
MAINT: Try accelerate

### DIFF
--- a/recipes/mne-python_1.1/construct.yaml
+++ b/recipes/mne-python_1.1/construct.yaml
@@ -76,6 +76,11 @@ specs:
   - mne-ari ~=0.1.0
   - mne-kit-gui ~=1.0.1
   - mne-icalabel ~=0.1.0  # [not win]
+  # OpenBLAS broken on arm64 https://github.com/numpy/numpy/issues/21756
+  - libblas =*accelerate  # [osx and arm64]
+  - libcblas =*accelerate  # [osx and arm64]
+  - liblapack =*accelerate  # [osx and arm64]
+  - liblapacke =*accelerate  # [osx and arm64]
   - autoreject ~=0.3.1
   - pyprep ~=0.4.0
   # Python

--- a/recipes/mne-python_1.1/construct.yaml
+++ b/recipes/mne-python_1.1/construct.yaml
@@ -77,10 +77,7 @@ specs:
   - mne-kit-gui ~=1.0.1
   - mne-icalabel ~=0.1.0  # [not win]
   # OpenBLAS broken on arm64 https://github.com/numpy/numpy/issues/21756
-  - libblas =*accelerate  # [osx and arm64]
-  - libcblas =*accelerate  # [osx and arm64]
-  - liblapack =*accelerate  # [osx and arm64]
-  - liblapacke =*accelerate  # [osx and arm64]
+  - libblas =*=*accelerate  # [osx and arm64]
   - autoreject ~=0.3.1
   - pyprep ~=0.4.0
   # Python


### PR DESCRIPTION
It seems a bit too invasive perhaps to make `mne` or `mne-base` force a specific `blas` version, so let's just do it here. This also allows us to be slower to update when the NumPy/OpenBLAS bug is actually fixed.

@hoechenberger I'm running `make pytest` locally on https://github.com/mne-tools/mne-python/pull/10763 after installing `accelerate`-based BLAS locally with `conda install -c -conda-forge "libblas=*=*accelerate`. I figured while that runs -- and hopefully comes back all good! -- I'd see if I got the syntax right here.