### PR TITLE
Include pycrostates 0.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,13 @@ concurrency:
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
     tags:
     - '*'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -95,7 +97,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Extract version information
-        shell: ${{ matrix.shell }} -el {0}
+        shell: '${{ matrix.shell }} -el {0}'
         env:
           MNE_CROSSCOMPILE_ARCH: ${{ matrix.arch }}
         run: |
@@ -129,7 +131,7 @@ jobs:
 
       - name: Add macOS M1 support
         if: ${{ matrix.arch == 'arm64' }}
-        shell: ${{ matrix.shell }} -el {0}
+        shell: '${{ matrix.shell }} -el {0}'
         run: |
           source ./tools/setup_m1_crosscompile.sh
           echo "EXE_ARG=${EXE_ARG}" >> $GITHUB_ENV
@@ -137,12 +139,12 @@ jobs:
 
       - name: Patch config (macOS pull request)
         if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
-        shell: ${{ matrix.shell }} -el {0}
+        shell: '${{ matrix.shell }} -el {0}'
         run: |
           sed -i "" "s/_name: *# \[osx\]/_name: 9779L28NP8  # \[osx\]/" ${RECIPE_DIR}/construct.yaml
 
       - name: Build installer
-        shell: ${{ matrix.shell }} -el {0}
+        shell: '${{ matrix.shell }} -el {0}'
         # As of 2022/03/14, ~7 min on 20.04 (fastest) and ~11 min on windows-2019 (slowest).
         # So let's set this to a reasonable limit that will tell us more quickly
         # if something has gone wrong with dependency resolution.
@@ -183,7 +185,7 @@ jobs:
           xcrun stapler staple ${MNE_INSTALLER_NAME}
 
       - name: Calculate SHA256 hash of installer package
-        shell: ${{ matrix.shell }} -el {0}
+        shell: '${{ matrix.shell }} -el {0}'
         run: |
           shopt -s nullglob  # Fail if the following pattern yields no results
           echo "Finding matches"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,16 +22,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: macos-10.15,  arch: x86_64 }
-          - { os: macos-11,     arch: arm64 }
-          - { os: ubuntu-18.04, arch: x86_64 }
-          - { os: windows-2019, arch: x86_64 }
+          - { os: macos-10.15,  arch: x86_64, shell: bash }
+          - { os: macos-11,     arch: arm64,  shell: bash }
+          - { os: ubuntu-18.04, arch: x86_64, shell: bash }
+          - { os: windows-2019, arch: x86_64, shell: msys2 }
 
     runs-on: ${{ matrix.os }}
 
     defaults:
       run:
-        shell: ${{ runner.os == 'Windows' && 'msys2 -el {0}' || 'bash -el {0}' }}
+        shell: ${{ matrix.shell == 'msys2' && 'msys2 -el {0}' || 'bash -el {0}' }}
 
     steps:
       - name: Setup MSYS2 (Windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,7 @@ jobs:
           echo ~
           echo $HOME
           env
+          source ~/.bash_profile
           conda list
 
       - name: Patch constructor

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Extract version information
-        shell: ${{ matrix.shell}} -el {0}
+        shell: ${{ matrix.shell }} -el {0}
         env:
           MNE_CROSSCOMPILE_ARCH: ${{ matrix.arch }}
         run: |
@@ -129,7 +129,7 @@ jobs:
 
       - name: Add macOS M1 support
         if: ${{ matrix.arch == 'arm64' }}
-        shell: ${{ matrix.shell}} -el {0}
+        shell: ${{ matrix.shell }} -el {0}
         run: |
           source ./tools/setup_m1_crosscompile.sh
           echo "EXE_ARG=${EXE_ARG}" >> $GITHUB_ENV
@@ -137,12 +137,12 @@ jobs:
 
       - name: Patch config (macOS pull request)
         if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
-        shell: ${{ matrix.shell}} -el {0}
+        shell: ${{ matrix.shell }} -el {0}
         run: |
           sed -i "" "s/_name: *# \[osx\]/_name: 9779L28NP8  # \[osx\]/" ${RECIPE_DIR}/construct.yaml
 
       - name: Build installer
-        shell: ${{ matrix.shell}} -el {0}
+        shell: ${{ matrix.shell }} -el {0}
         # As of 2022/03/14, ~7 min on 20.04 (fastest) and ~11 min on windows-2019 (slowest).
         # So let's set this to a reasonable limit that will tell us more quickly
         # if something has gone wrong with dependency resolution.
@@ -183,7 +183,7 @@ jobs:
           xcrun stapler staple ${MNE_INSTALLER_NAME}
 
       - name: Calculate SHA256 hash of installer package
-        shell: ${{ matrix.shell}} -el {0}
+        shell: ${{ matrix.shell }} -el {0}
         run: |
           shopt -s nullglob  # Fail if the following pattern yields no results
           echo "Finding matches"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           echo "RECIPE_DIR=${RECIPE_DIR}" >> $GITHUB_ENV
 
       - name: Install Micromamba
-        uses: mamba-org/provision-with-micromamba@v11
+        uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environment.yml
           micromamba-version: latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,13 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+
     steps:
       - name:  Use bash from MSYS2 on Windows
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run:   |
-          echo "{C:\msys64\usr\bin}" >> $GITHUB_PATH
+          echo "C:\msys64\usr\bin" >> $GITHUB_PATH
 
       # Based on https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
       - name: Install code-signing certificates (macOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,21 @@ jobs:
     strategy:
       matrix:
         include:
-          # - { os: macos-10.15,  arch: x86_64, shell: bash }
-          # - { os: macos-11,     arch: arm64,  shell: bash }
-          # - { os: ubuntu-18.04, arch: x86_64, shell: bash }
-          - { os: windows-2019, arch: x86_64, shell: msys2 }
+          - os: macos-10.15
+            arch: x86_64
+            shell: bash
+
+          - os: macos-11
+            arch: arm64
+            shell: bash
+
+          - os: ubuntu-18.04
+            arch: x86_64
+            shell: bash
+
+          - os: windows-2019
+            arch: x86_64
+            shell: msys2  # it's in fact a bash shell, too
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,9 @@ jobs:
           echo ~
           echo $HOME
           env
+          $MAMBA_EXE shell init -p $MAMBA_ROOT_PREFIX -y
           source ~/.bash_profile
+          micromamba activate constructor-env
           conda list
 
       - name: Patch constructor

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,18 +129,6 @@ jobs:
           environment-file: environment.yml
           micromamba-version: latest
 
-      - name: Debugging output
-        if: ${{ runner.os == 'Windows' }}
-        run: |
-          echo ~
-          echo $HOME
-          # env
-          # $MAMBA_EXE shell init -p $MAMBA_ROOT_PREFIX -y
-          # source ~/.bash_profile
-          eval "$(micromamba shell hook --shell=bash)"
-          micromamba activate constructor-env
-          conda list
-
       - name: Patch constructor
         run: |
           ./tools/patch_constructor.sh
@@ -166,6 +154,10 @@ jobs:
         #                    Linux
         timeout-minutes: 40
         run: |
+          # Unnecessary on macOS & Linux, but required for Windows (why?)
+          eval "$(micromamba shell hook --shell=bash)"
+          micromamba activate constructor-env
+
           ./tools/run_constructor.sh
 
       - name: Check installer signature (macOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,8 +132,10 @@ jobs:
       - name: Print some debugging output
         run: |
           echo $HOME
+          echo ~
           cat ~/.bash_profile
           cat ~/.bashrc
+          mamba env list
 
       - name: Patch constructor
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,15 +129,6 @@ jobs:
           environment-file: environment.yml
           micromamba-version: latest
 
-      - name: Print some debugging output
-        run: |
-          echo $HOME
-          echo ~
-          cat ~/.bash_profile
-          cat ~/.bashrc
-          ${MAMBA_EXE} activate ${MAMBA_ROOT_PREFIX}
-          conda list
-
       - name: Patch constructor
         run: |
           ./tools/patch_constructor.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,7 @@ jobs:
         run: |
           echo $HOME
           cat ~/.bash_profile
+          cat ~/.bashrc
 
       - name: Patch constructor
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,8 @@ jobs:
           echo ~
           cat ~/.bash_profile
           cat ~/.bashrc
-          mamba env list
+          ${MAMBA_EXE} activate ${MAMBA_ROOT_PREFIX}
+          conda list
 
       - name: Patch constructor
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Setup MSYS2 (Windows)
         if: ${{ runner.os == 'Windows' }}
         uses: msys2/setup-msys2@v2
+        with:
+          path-type: inherit
 
       # Based on https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
       - name: Install code-signing certificates (macOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,10 @@ jobs:
 
       - name: Patch constructor
         run: |
+          # Unnecessary on macOS & Linux, but required for Windows (why?)
+          eval "$(micromamba shell hook --shell=bash)"
+          micromamba activate constructor-env
+
           ./tools/patch_constructor.sh
 
       - name: Add macOS M1 support

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Extract version information
-        shell: '${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}'
+        shell: ${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}
         env:
           MNE_CROSSCOMPILE_ARCH: ${{ matrix.arch }}
         run: |
@@ -125,13 +125,13 @@ jobs:
           micromamba-version: latest
 
       - name: Patch constructor
-        shell: '${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}'
+        shell: ${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}
         run: |
           ./tools/patch_constructor.sh
 
       - name: Add macOS M1 support
         if: ${{ matrix.arch == 'arm64' }}
-        shell: '${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}'
+        shell: ${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}
         run: |
           source ./tools/setup_m1_crosscompile.sh
           echo "EXE_ARG=${EXE_ARG}" >> $GITHUB_ENV
@@ -139,12 +139,12 @@ jobs:
 
       - name: Patch config (macOS pull request)
         if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
-        shell: '${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}'
+        shell: ${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}
         run: |
           sed -i "" "s/_name: *# \[osx\]/_name: 9779L28NP8  # \[osx\]/" ${RECIPE_DIR}/construct.yaml
 
       - name: Build installer
-        shell: '${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}'
+        shell: ${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}
         # As of 2022/03/14, ~7 min on 20.04 (fastest) and ~11 min on windows-2019 (slowest).
         # So let's set this to a reasonable limit that will tell us more quickly
         # if something has gone wrong with dependency resolution.
@@ -185,7 +185,7 @@ jobs:
           xcrun stapler staple ${MNE_INSTALLER_NAME}
 
       - name: Calculate SHA256 hash of installer package
-        shell: '${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}'
+        shell: ${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}
         run: |
           shopt -s nullglob  # Fail if the following pattern yields no results
           echo "Finding matches"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name:  Use bash from MSYS2 on Windows
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run:   |
+          echo "{C:\msys64\usr\bin}" >> $GITHUB_PATH
+
       # Based on https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
       - name: Install code-signing certificates (macOS)
         if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,11 @@ jobs:
           environment-file: environment.yml
           micromamba-version: latest
 
+      - name: Print some debugging output
+        run: |
+          echo $HOME
+          cat ~/.bash_profile
+
       - name: Patch constructor
         run: |
           ./tools/patch_constructor.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,21 +19,18 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
-        arch: [x86_64]
         include:
-          - os: macos-11
-            arch: arm64
+          - { os: macos-10.15,  arch: x86_64, shell: bash }
+          - { os: macos-11,     arch: arm64,  shell: bash }
+          - { os: ubuntu-18.04, arch: x86_64, shell: bash }
+          - { os: windows-2019, arch: x86_64, shell: msys2 }
 
     runs-on: ${{ matrix.os }}
 
-
     steps:
-      - name:  Use bash from MSYS2 on Windows
+      - name: Setup MSYS2 (Windows)
         if: ${{ runner.os == 'Windows' }}
-        shell: pwsh
-        run:   |
-          echo "C:\msys64\usr\bin" >> $GITHUB_PATH
+        uses: msys2/setup-msys2@v2
 
       # Based on https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
       - name: Install code-signing certificates (macOS)
@@ -98,7 +95,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Extract version information
-        shell: bash -el {0}
+        shell: ${{ matrix.shell}} -el {0}
         env:
           MNE_CROSSCOMPILE_ARCH: ${{ matrix.arch }}
         run: |
@@ -132,7 +129,7 @@ jobs:
 
       - name: Add macOS M1 support
         if: ${{ matrix.arch == 'arm64' }}
-        shell: bash -el {0}
+        shell: ${{ matrix.shell}} -el {0}
         run: |
           source ./tools/setup_m1_crosscompile.sh
           echo "EXE_ARG=${EXE_ARG}" >> $GITHUB_ENV
@@ -140,12 +137,12 @@ jobs:
 
       - name: Patch config (macOS pull request)
         if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
-        shell: bash -el {0}
+        shell: ${{ matrix.shell}} -el {0}
         run: |
           sed -i "" "s/_name: *# \[osx\]/_name: 9779L28NP8  # \[osx\]/" ${RECIPE_DIR}/construct.yaml
 
       - name: Build installer
-        shell: bash -el {0}
+        shell: ${{ matrix.shell}} -el {0}
         # As of 2022/03/14, ~7 min on 20.04 (fastest) and ~11 min on windows-2019 (slowest).
         # So let's set this to a reasonable limit that will tell us more quickly
         # if something has gone wrong with dependency resolution.
@@ -186,7 +183,7 @@ jobs:
           xcrun stapler staple ${MNE_INSTALLER_NAME}
 
       - name: Calculate SHA256 hash of installer package
-        shell: bash -el {0}
+        shell: ${{ matrix.shell}} -el {0}
         run: |
           shopt -s nullglob  # Fail if the following pattern yields no results
           echo "Finding matches"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    defaults:
+      run:
+        shell: ${{ runner.os == 'Windows' && 'msys2 -el {0}' || 'bash -el {0}' }}
+
     steps:
       - name: Setup MSYS2 (Windows)
         if: ${{ runner.os == 'Windows' }}
@@ -97,7 +101,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Extract version information
-        shell: ${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}
         env:
           MNE_CROSSCOMPILE_ARCH: ${{ matrix.arch }}
         run: |
@@ -125,13 +128,11 @@ jobs:
           micromamba-version: latest
 
       - name: Patch constructor
-        shell: ${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}
         run: |
           ./tools/patch_constructor.sh
 
       - name: Add macOS M1 support
         if: ${{ matrix.arch == 'arm64' }}
-        shell: ${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}
         run: |
           source ./tools/setup_m1_crosscompile.sh
           echo "EXE_ARG=${EXE_ARG}" >> $GITHUB_ENV
@@ -139,12 +140,10 @@ jobs:
 
       - name: Patch config (macOS pull request)
         if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
-        shell: ${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}
         run: |
           sed -i "" "s/_name: *# \[osx\]/_name: 9779L28NP8  # \[osx\]/" ${RECIPE_DIR}/construct.yaml
 
       - name: Build installer
-        shell: ${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}
         # As of 2022/03/14, ~7 min on 20.04 (fastest) and ~11 min on windows-2019 (slowest).
         # So let's set this to a reasonable limit that will tell us more quickly
         # if something has gone wrong with dependency resolution.
@@ -185,7 +184,6 @@ jobs:
           xcrun stapler staple ${MNE_INSTALLER_NAME}
 
       - name: Calculate SHA256 hash of installer package
-        shell: ${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}
         run: |
           shopt -s nullglob  # Fail if the following pattern yields no results
           echo "Finding matches"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           echo "RECIPE_DIR=${RECIPE_DIR}" >> $GITHUB_ENV
 
       - name: Install Micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/provision-with-micromamba@v11
         with:
           environment-file: environment.yml
           micromamba-version: latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: macos-10.15,  arch: x86_64, shell: bash }
-          - { os: macos-11,     arch: arm64,  shell: bash }
-          - { os: ubuntu-18.04, arch: x86_64, shell: bash }
-          - { os: windows-2019, arch: x86_64, shell: msys2 }
+          - { os: macos-10.15,  arch: x86_64 }
+          - { os: macos-11,     arch: arm64 }
+          - { os: ubuntu-18.04, arch: x86_64 }
+          - { os: windows-2019, arch: x86_64 }
 
     runs-on: ${{ matrix.os }}
 
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Extract version information
-        shell: '${{ matrix.shell }} -el {0}'
+        shell: '${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}'
         env:
           MNE_CROSSCOMPILE_ARCH: ${{ matrix.arch }}
         run: |
@@ -125,13 +125,13 @@ jobs:
           micromamba-version: latest
 
       - name: Patch constructor
-        shell: bash -el {0}
+        shell: '${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}'
         run: |
           ./tools/patch_constructor.sh
 
       - name: Add macOS M1 support
         if: ${{ matrix.arch == 'arm64' }}
-        shell: '${{ matrix.shell }} -el {0}'
+        shell: '${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}'
         run: |
           source ./tools/setup_m1_crosscompile.sh
           echo "EXE_ARG=${EXE_ARG}" >> $GITHUB_ENV
@@ -139,12 +139,12 @@ jobs:
 
       - name: Patch config (macOS pull request)
         if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
-        shell: '${{ matrix.shell }} -el {0}'
+        shell: '${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}'
         run: |
           sed -i "" "s/_name: *# \[osx\]/_name: 9779L28NP8  # \[osx\]/" ${RECIPE_DIR}/construct.yaml
 
       - name: Build installer
-        shell: '${{ matrix.shell }} -el {0}'
+        shell: '${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}'
         # As of 2022/03/14, ~7 min on 20.04 (fastest) and ~11 min on windows-2019 (slowest).
         # So let's set this to a reasonable limit that will tell us more quickly
         # if something has gone wrong with dependency resolution.
@@ -185,7 +185,7 @@ jobs:
           xcrun stapler staple ${MNE_INSTALLER_NAME}
 
       - name: Calculate SHA256 hash of installer package
-        shell: '${{ matrix.shell }} -el {0}'
+        shell: '${{ runner.os == 'Windows' && 'msys2' || 'bash' }} -el {0}'
         run: |
           shopt -s nullglob  # Fail if the following pattern yields no results
           echo "Finding matches"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,13 +40,6 @@ jobs:
         with:
           path-type: inherit
 
-      - name: Debugging output
-        if: ${{ runner.os == 'Windows' }}
-        shell: msys2 {0}
-        run: |
-          echo ~
-          echo $HOME
-
       # Based on https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
       - name: Install code-signing certificates (macOS)
         if: ${{ runner.os == 'macOS' && github.event_name != 'pull_request' }}
@@ -135,6 +128,14 @@ jobs:
         with:
           environment-file: environment.yml
           micromamba-version: latest
+
+      - name: Debugging output
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          echo ~
+          echo $HOME
+          env
+          conda list
 
       - name: Patch constructor
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,9 +134,10 @@ jobs:
         run: |
           echo ~
           echo $HOME
-          env
-          $MAMBA_EXE shell init -p $MAMBA_ROOT_PREFIX -y
-          source ~/.bash_profile
+          # env
+          # $MAMBA_EXE shell init -p $MAMBA_ROOT_PREFIX -y
+          # source ~/.bash_profile
+          eval "$(micromamba shell hook --shell=bash)"
           micromamba activate constructor-env
           conda list
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: macos-10.15,  arch: x86_64, shell: bash }
-          - { os: macos-11,     arch: arm64,  shell: bash }
-          - { os: ubuntu-18.04, arch: x86_64, shell: bash }
+          # - { os: macos-10.15,  arch: x86_64, shell: bash }
+          # - { os: macos-11,     arch: arm64,  shell: bash }
+          # - { os: ubuntu-18.04, arch: x86_64, shell: bash }
           - { os: windows-2019, arch: x86_64, shell: msys2 }
 
     runs-on: ${{ matrix.os }}
@@ -39,6 +39,13 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           path-type: inherit
+
+      - name: Debugging output
+        if: ${{ runner.os == 'Windows' }}
+        shell: msys2 {0}
+        run: |
+          echo ~
+          echo $HOME
 
       # Based on https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
       - name: Install code-signing certificates (macOS)

--- a/recipes/mne-python_1.1/construct.yaml
+++ b/recipes/mne-python_1.1/construct.yaml
@@ -109,7 +109,7 @@ specs:
   - fooof
   # Microstates
   - mne-microstates ~=0.3.0
-  - pycrostates ~=0.1.1
+  - pycrostates ~=0.1.2
   # MNE-BIDS-Pipeline
   # try to keep this in sync with https://github.com/mne-tools/mne-bids-pipeline/blob/main/requirements.txt
   # note that many dependencies listed there are redundant and need not be explicitly listed here


### PR DESCRIPTION
We fixed a reported issue in the packaging: the `.jinja` files were not included in the tarball and the wheel. Oopsie 😅 
It would be nice if this bugfix release could be included in the installers for 1.1. Depends on https://github.com/conda-forge/pycrostates-feedstock/pull/4

One question, what does the operator `~=` do exactly?