### PR TITLE
Update numerous bundled packages and add automated check for outdated packages

### DIFF
--- a/recipes/mne-python_1.1/construct.yaml
+++ b/recipes/mne-python_1.1/construct.yaml
@@ -65,21 +65,21 @@ specs:
 
   # - mne =1.0.3=*_1
   # - mne-installer-menus =1.0.3=*_1
-  - mne-qt-browser ~=0.3.0
-  - mne-bids ~=0.10.0
-  - mne-connectivity ~=0.3.0
-  - mne-faster ~=1.1.0
-  - mne-nirs ~=0.2.0
-  - mne-realtime ~=0.1.0
-  - mne-features ~=0.2.0
-  - mne-rsa ~=0.6.0
-  - mne-ari ~=0.1.0
-  - mne-kit-gui ~=1.0.1
-  - mne-icalabel ~=0.1.0  # [not win]
-  - autoreject ~=0.3.1
-  - pyprep ~=0.4.0
+  - mne-qt-browser =0.3.1
+  - mne-bids =0.10
+  - mne-connectivity =0.3
+  - mne-faster =1.1.0
+  - mne-nirs =0.2.1
+  - mne-realtime =0.1.3
+  - mne-features =0.2
+  - mne-rsa =0.6.0
+  - mne-ari =0.1.1
+  - mne-kit-gui =1.0.1
+  - mne-icalabel =0.2  # [not win]
+  - autoreject =0.3.1
+  - pyprep =0.4.2
   # Python
-  - python ~=3.10.0
+  - python =3.10.5
   - pip
   - conda
   - mamba
@@ -109,8 +109,8 @@ specs:
   - bycycle
   - fooof
   # Microstates
-  - mne-microstates ~=0.3.0
-  - pycrostates ~=0.1.2
+  - mne-microstates =0.3.0
+  - pycrostates =0.1.2
   # MNE-BIDS-Pipeline
   # try to keep this in sync with https://github.com/mne-tools/mne-bids-pipeline/blob/main/requirements.txt
   # note that many dependencies listed there are redundant and need not be explicitly listed here

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -1,0 +1,71 @@
+# %%
+from pathlib import Path
+from dataclasses import dataclass
+
+import yaml
+import requests
+import packaging
+
+recipes_dir = Path(__file__).parents[1] / 'recipes'
+recipies = sorted([
+    str(recipe) for recipe in recipes_dir.iterdir()
+    if recipe.is_dir()
+])
+latest_recipe_dir = Path(recipies[-1])
+construct_yaml_path = latest_recipe_dir / 'construct.yaml'
+
+construct_yaml = yaml.safe_load(
+    construct_yaml_path.read_text(encoding='utf-8')
+)
+specs = construct_yaml['specs']
+
+@dataclass
+class Package:
+    name: str
+    version: str | None
+
+packages: list[Package] = []
+
+for spec in specs:
+    if ' ' in spec:
+        name, version = spec.split(' ')
+        version = (
+            version
+            .lstrip('~')
+            .lstrip('=')
+            .split('=')  # build number
+        )[0]
+    else:
+        name = spec
+        version = None
+
+    packages.append(
+        Package(name, version)
+    )
+
+outdated = []
+not_found = []
+for package in packages:
+    if package.version is None:
+        continue
+
+    pypi_url = f'https://pypi.org/pypi/{package.name}/json'
+    r =  requests.get(pypi_url)
+    if r.status_code == 404:
+        print(f'{package.name} not found on PyPI')
+        not_found.append(package)
+        continue
+
+    json = r.json()
+    pypi_version = json['info']['version']
+    if (
+        packaging.version.parse(package.version) <
+        packaging.version.parse(pypi_version)
+    ):
+        print(f'{package.name} is outdated')
+        outdated.append(package)
+    else:
+        print(f'{package.name} is up to date')
+
+print(f'\n{len(not_found)} packages not found on PyPI:\n{not_found}')
+print(f'\n{len(outdated)} packages are outdated:\n{outdated}')


### PR DESCRIPTION
@larsoner This is WIP work to automatically find out which packages are potentially outdated.

My idea is to add this to a CI job to run weekly or so.

Please feel free to take over if you have time. It's already sort of useful, I suppose:

```
mne is up to date
mne-installer-menus not found on PyPI
openblas not found on PyPI
mne-qt-browser is outdated
mne-bids is up to date
mne-connectivity is up to date
mne-faster is up to date
mne-nirs is outdated
mne-realtime is outdated
mne-features is up to date
mne-rsa is outdated
mne-ari is outdated
mne-kit-gui is up to date
mne-icalabel is outdated
autoreject is up to date
pyprep is outdated
python not found on PyPI
mne-microstates is up to date
pycrostates is up to date

3 packages not found on PyPI:
[Package(name='mne-installer-menus', version='1.1dev0'), Package(name='openblas', version='0.3.20'), Package(name='python', version='3.10.0')]

7 packages are outdated:
[Package(name='mne-qt-browser', version='0.3.0'), Package(name='mne-nirs', version='0.2.0'), Package(name='mne-realtime', version='0.1.0'), Package(name='mne-rsa', version='0.6.0'), Package(name='mne-ari', version='0.1.0'), Package(name='mne-icalabel', version='0.1.0'), Package(name='pyprep', version='0.4.0')]
```