### PR TITLE
MAINT: Bump to 1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-10.15
+          - os: macos-11
             arch: x86_64
             shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11, windows-2019, windows-2022]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-11, macos-12, windows-2019, windows-2022]
         arch: [x86_64]
         # We currently can't/don't test anything about the arm64 build
         # include:

--- a/recipes/mne-python_1.1/construct.yaml
+++ b/recipes/mne-python_1.1/construct.yaml
@@ -63,21 +63,21 @@ specs:
 
   - mne =1.1.0=*_0
   - mne-installer-menus =1.1.0=*_0
-  - mne-qt-browser ~=0.3.1
-  - mne-bids ~=0.10
-  - mne-connectivity ~=0.3
-  - mne-faster ~=1.1.0
-  - mne-nirs ~=0.2.1
-  - mne-realtime ~=0.1.3
-  - mne-features ~=0.2
-  - mne-rsa ~=0.6.0
-  - mne-ari ~=0.1.1
-  - mne-kit-gui ~=1.0.1
-  - mne-icalabel ~=0.2  # [not win]
-  - autoreject ~=0.3.1
-  - pyprep ~=0.4.2
+  - mne-qt-browser =0.3.1
+  - mne-bids =0.10
+  - mne-connectivity =0.3
+  - mne-faster =1.1.0
+  - mne-nirs =0.2.1
+  - mne-realtime =0.1.3
+  - mne-features =0.2
+  - mne-rsa =0.6.0
+  - mne-ari =0.1.1
+  - mne-kit-gui =1.0.1
+  - mne-icalabel =0.2  # [not win]
+  - autoreject =0.3.1
+  - pyprep =0.4.2
   # Python
-  - python ~=3.10.0
+  - python =3.10.5
   - pip
   - conda
   - mamba

--- a/recipes/mne-python_1.1/construct.yaml
+++ b/recipes/mne-python_1.1/construct.yaml
@@ -1,4 +1,4 @@
-version: 1.1.0_dev0
+version: 1.1.0_0
 name: MNE-Python
 company: MNE-Python Developers
 # When the version above changes to a new major/minor, it needs to be updated
@@ -18,17 +18,17 @@ initialize_by_default: False
 register_python_default: False
 
 # default_prefix will be ignored by macOS .pkg installer!
-default_prefix: ${HOME}/mne-python/1.1.0_dev0                          # [linux]
-default_prefix: "%USERPROFILE%\\mne-python\\1.1.0_dev0"                # [win]
-default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.1.0_dev0"   # [win]
-default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.1.0_dev0"  # [win]
+default_prefix: ${HOME}/mne-python/1.1.0_0                          # [linux]
+default_prefix: "%USERPROFILE%\\mne-python\\1.1.0_0"                # [win]
+default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.1.0_0"   # [win]
+default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.1.0_0"  # [win]
 
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
-installer_filename: MNE-Python-1.1.0_dev0-macOS_Intel.pkg  # [osx and not arm64]
-installer_filename: MNE-Python-1.1.0_dev0-macOS_M1.pkg     # [osx and arm64]
-installer_filename: MNE-Python-1.1.0_dev0-Windows.exe      # [win]
-installer_filename: MNE-Python-1.1.0_dev0-Linux.sh         # [linux]
+installer_filename: MNE-Python-1.1.0_0-macOS_Intel.pkg  # [osx and not arm64]
+installer_filename: MNE-Python-1.1.0_0-macOS_M1.pkg     # [osx and arm64]
+installer_filename: MNE-Python-1.1.0_0-Windows.exe      # [win]
+installer_filename: MNE-Python-1.1.0_0-Linux.sh         # [linux]
 
 post_install: ../../assets/post_install_macOS.sh        # [osx]
 post_install: ../../assets/post_install_linux.sh        # [linux]
@@ -47,7 +47,7 @@ menu_packages:
 channels:
   - conda-forge
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: COMMENT OUT BEFORE RELEASE! ⛔️ ⛔️ ⛔️
-  - conda-forge/label/mne_dev
+  # - conda-forge/label/mne_dev
   # - conda-forge/label/mne-bids_dev
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: COMMENT OUT BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 
@@ -55,31 +55,29 @@ specs:
   # MNE ecosystem
 
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
-  - mne =1.1dev0=*_20220728
-  - mne-installer-menus =1.1dev0=*_20220728
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP START ⛔️ ⛔️ ⛔️
   - openblas =0.3.20=*_1  # [osx and arm64]
   # TODO: ⛔️ ⛔️ ⛔️ REMOVE ASAP STOP ⛔️ ⛔️ ⛔️
 
-  # - mne =1.0.3=*_1
-  # - mne-installer-menus =1.0.3=*_1
-  - mne-qt-browser =0.3.1
-  - mne-bids =0.10
-  - mne-connectivity =0.3
-  - mne-faster =1.1.0
-  - mne-nirs =0.2.1
-  - mne-realtime =0.1.3
-  - mne-features =0.2
-  - mne-rsa =0.6.0
-  - mne-ari =0.1.1
-  - mne-kit-gui =1.0.1
-  - mne-icalabel =0.2  # [not win]
-  - autoreject =0.3.1
-  - pyprep =0.4.2
+  - mne =1.1.0=*_0
+  - mne-installer-menus =1.1.0=*_0
+  - mne-qt-browser ~=0.3.1
+  - mne-bids ~=0.10
+  - mne-connectivity ~=0.3
+  - mne-faster ~=1.1.0
+  - mne-nirs ~=0.2.1
+  - mne-realtime ~=0.1.3
+  - mne-features ~=0.2
+  - mne-rsa ~=0.6.0
+  - mne-ari ~=0.1.1
+  - mne-kit-gui ~=1.0.1
+  - mne-icalabel ~=0.2  # [not win]
+  - autoreject ~=0.3.1
+  - pyprep ~=0.4.2
   # Python
-  - python =3.10.5
+  - python ~=3.10.0
   - pip
   - conda
   - mamba
@@ -137,4 +135,4 @@ condarc:
     - conda-forge
   channel_priority: strict
   allow_other_channels: False
-  env_prompt: "(mne-1.1.0_dev0) "
+  env_prompt: "(mne-1.1.0_0) "


### PR DESCRIPTION
This won't work until @drammock cuts a 1.1.0 release on Github, conda-forge updates the feedstock, and then the CDNs update, but in the meantime I wanted to set this up so it's ready to go (restart CIs then be green hopefully!).

@hoechenberger feel free to review to make sure this is reasonable. I changed some `=0.3.1` to `~=0.3.1` since it seems like we should be okay with newer patch releases being installed, right?