### PR TITLE
MAINT: Use extended validation for Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
   # Build installers
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-11
@@ -208,6 +209,7 @@ jobs:
           # Staple the notarization certificate onto it
           xcrun stapler staple ${MNE_INSTALLER_NAME}
 
+      # Note: if this changes, it needs to be changed in the Windows signing step as well
       - name: Calculate SHA256 hash of installer package
         run: |
           shopt -s nullglob  # Fail if the following pattern yields no results
@@ -235,10 +237,67 @@ jobs:
           name: ${{ env.MNE_INSTALLER_ARTIFACT_ID }}
           path: MNE-Python-*.*
 
+  # The Windows signing needs to be done on Linux
+  # https://www.ssl.com/how-to/cloud-code-signing-integration-with-github-actions/
+  sign:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Determine installer name (cross-OS)
+        if: github.event_name != 'pull_request'
+        shell: bash -el {0}
+        run: |
+          source ./tools/extract_version.sh Windows
+          echo "MNE_INSTALLER_ARTIFACT_ID=${MNE_INSTALLER_ARTIFACT_ID}" >> $GITHUB_ENV
+          echo "MNE_INSTALLER_NAME=${MNE_INSTALLER_NAME}" >> $GITHUB_ENV
+          echo "MNE_INSTALLER_VERSION=${MNE_INSTALLER_VERSION}" >> $GITHUB_ENV
+          mkdir signed
+      - name: Download appropriate installer
+        if: github.event_name != 'pull_request'
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.MNE_INSTALLER_ARTIFACT_ID }}
+      - name: EV-code sign installer (Windows)
+        if: github.event_name != 'pull_request'
+        uses: sslcom/actions-codesigner@develop
+        with:
+          command: sign
+          username: ${{ secrets.ES_USERNAME }}
+          password: ${{ secrets.ES_PASSWORD }}
+          credential_id: ${{ secrets.ES_CREDENTIAL_ID }}
+          totp_secret: ${{ secrets.ES_TOTP_SECRET }}
+          file_path: ${GITHUB_WORKSPACE}/${{ env.MNE_INSTALLER_NAME }}
+          output_path: ${GITHUB_WORKSPACE}/signed
+      - name: Calculate new SHA256 hash of installer package
+        run: |
+          mv signed/${MNE_INSTALLER_NAME} .
+          shopt -s nullglob  # Fail if the following pattern yields no results
+          echo "Finding matches"
+          matches=(MNE-Python-*-*.*)
+          echo "Extracting fname"
+          installer_fname="${matches[0]}"
+          echo "Found name: ${installer_fname}"
+          echo "Want name:  ${MNE_INSTALLER_NAME}"
+          test "$installer_fname" == "$MNE_INSTALLER_NAME"
+          hash_fname="${MNE_INSTALLER_NAME}.sha256.txt"
+          echo "Old hash:"
+          cat "$hash_fname"
+          shasum -a 256 "$MNE_INSTALLER_NAME" > "$hash_fname"
+          echo "New hash:"
+          cat "$hash_fname"
+      - name: Overwrite artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.MNE_INSTALLER_ARTIFACT_ID }}
+          path: MNE-Python-*.*
+
   # Test
   test:
-    needs: build
+    needs: [build, sign]
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-11, macos-12, windows-2019, windows-2022]
         arch: [x86_64]
@@ -279,6 +338,12 @@ jobs:
         run: |
           echo `pwd`
           sh ./${MNE_INSTALLER_NAME} -b
+
+      - name: Check installer signing (Windows)
+        if: ${{ runner.os == 'Windows' && github.event_name != 'pull_request' }}
+        shell: cmd
+        run: |
+          "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe" verify /pa /v .\%MNE_INSTALLER_NAME%
 
       # https://docs.anaconda.com/anaconda/install/silent-mode.html
       - name: Run installer (Windows)
@@ -434,7 +499,7 @@ jobs:
 
   # Release
   release:
-    needs: [build, test]
+    needs: [build, sign, test]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,6 +270,7 @@ jobs:
           file_path: ${GITHUB_WORKSPACE}/${{ env.MNE_INSTALLER_NAME }}
           output_path: ${GITHUB_WORKSPACE}/signed
       - name: Calculate new SHA256 hash of installer package
+        if: github.event_name != 'pull_request'
         run: |
           mv signed/${MNE_INSTALLER_NAME} .
           shopt -s nullglob  # Fail if the following pattern yields no results

--- a/tools/extract_version.sh
+++ b/tools/extract_version.sh
@@ -7,12 +7,16 @@ export MNE_INSTALLER_VERSION=$(head -n 1 recipes/mne-python_${VER}/construct.yam
 export RECIPE_DIR=${SCRIPT_DIR}/../recipes/mne-python_$(echo $MNE_INSTALLER_VERSION | cut -d . -f-2)
 export PYSHORT=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
 UNAME="$(uname -s)"
-case "${UNAME}" in
-    Linux*)      MACHINE=Linux;;
-    Darwin*)     MACHINE=macOS;;
-    MINGW64_NT*) MACHINE=Windows;;
-    *)           MACHINE="UNKNOWN:${UNAME}"
-esac
+if [[ "$1" != "" ]]; then
+    MACHINE="$1"
+else
+    case "${UNAME}" in
+        Linux*)      MACHINE=Linux;;
+        Darwin*)     MACHINE=macOS;;
+        MINGW64_NT*) MACHINE=Windows;;
+        *)           MACHINE="UNKNOWN:${UNAME}"
+    esac
+fi
 if [[ "$MACHINE" != "macOS" && "$MACHINE" != "Linux" && "$MACHINE" != "Windows" ]]; then
     echo "Unknown machine: ${UNAME}"
     exit 1


### PR DESCRIPTION
On https://github.com/mne-tools/mne-installers/actions/runs/3176256884/jobs/5175882589 the extended verification worked:
```
2022-10-03T18:28:11.3103387Z Verifying: .\MNE-Python-1.1.1_0-Windows.exe
2022-10-03T18:28:11.3104321Z Signature Index: 0 (Primary Signature)
2022-10-03T18:28:11.3105245Z Hash of file (sha256): 6B35806155C2098AA3531485EECA1A66D56D5FB670011FEEA6DE48FF68B43DD7
2022-10-03T18:28:11.3113330Z Signing Certificate Chain:
2022-10-03T18:28:11.3113878Z     Issued to: Certum Trusted Network CA
2022-10-03T18:28:11.3116216Z     Issued by: Certum Trusted Network CA
2022-10-03T18:28:11.3116784Z     Expires:   Mon Dec 31 12:07:37 2029
...
2022-10-03T18:28:11.3391176Z Successfully verified: .\MNE-Python-1.1.1_0-Windows.exe
2022-10-03T18:28:11.3402007Z Number of files successfully Verified: 1
2022-10-03T18:28:11.3413874Z Number of warnings: 0
2022-10-03T18:28:11.3414200Z Number of errors: 0
```
I want to test locally that our latest 1.1.1 installer from https://mne.tools/dev/install/index.html *does* emit a bunch of warnings when you try to use it, but the artifact from that GH Actions run *does not*. But I expect it to, so we can merge this when green I think.