### PR TITLE
MAINT: Update deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           - os: macos-11
             arch: arm64
 
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             arch: x86_64
 
           - os: windows-2019
@@ -282,7 +282,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-11, macos-12, windows-2019, windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022]
         arch: [x86_64]
         # We currently can't/don't test anything about the arm64 build
         # include:

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - conda-standalone =4.12a=*_9
   - menuinst =2.0a=14_g594d642_*
   - conda =4.12a
-  - mamba
+  - mamba =1.1.0

--- a/recipes/mne-python_1.3/construct.yaml
+++ b/recipes/mne-python_1.3/construct.yaml
@@ -129,7 +129,7 @@ specs:
   - ipympl
   - seaborn
   - plotly
-  - vtk =9.2.6
+  - vtk =9.2.5
   # Temporary
   # for VS Code compatibility: https://github.com/microsoft/vscode-jupyter/issues/8552#issuecomment-1263940999
   - ipywidgets <8

--- a/recipes/mne-python_1.3/construct.yaml
+++ b/recipes/mne-python_1.3/construct.yaml
@@ -1,4 +1,4 @@
-version: 1.3.0_0
+version: 1.3.0_1
 name: MNE-Python
 company: MNE-Python Developers
 # When the version above changes to a new major/minor, it needs to be updated
@@ -18,17 +18,17 @@ initialize_by_default: False
 register_python_default: False
 
 # default_prefix will be ignored by macOS .pkg installer!
-default_prefix: ${HOME}/mne-python/1.3.0_0                          # [linux]
-default_prefix: "%USERPROFILE%\\mne-python\\1.3.0_0"                # [win]
-default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.3.0_0"   # [win]
-default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.3.0_0"  # [win]
+default_prefix: ${HOME}/mne-python/1.3.0_1                          # [linux]
+default_prefix: "%USERPROFILE%\\mne-python\\1.3.0_1"                # [win]
+default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.3.0_1"   # [win]
+default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.3.0_1"  # [win]
 
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
-installer_filename: MNE-Python-1.3.0_0-macOS_Intel.pkg  # [osx and not arm64]
-installer_filename: MNE-Python-1.3.0_0-macOS_M1.pkg     # [osx and arm64]
-installer_filename: MNE-Python-1.3.0_0-Windows.exe      # [win]
-installer_filename: MNE-Python-1.3.0_0-Linux.sh         # [linux]
+installer_filename: MNE-Python-1.3.0_1-macOS_Intel.pkg  # [osx and not arm64]
+installer_filename: MNE-Python-1.3.0_1-macOS_M1.pkg     # [osx and arm64]
+installer_filename: MNE-Python-1.3.0_1-Windows.exe      # [win]
+installer_filename: MNE-Python-1.3.0_1-Linux.sh         # [linux]
 
 post_install: ../../assets/post_install_macOS.sh        # [osx]
 post_install: ../../assets/post_install_linux.sh        # [linux]
@@ -46,6 +46,8 @@ menu_packages:
 
 channels:
   - conda-forge
+  # conda-forge doesn't provide pytorch packages for Windows
+  # - pytorch  # [win]
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: COMMENT OUT BEFORE RELEASE! ⛔️ ⛔️ ⛔️
   # - conda-forge/label/mne_dev
   # - conda-forge/label/mne-bids_dev
@@ -63,18 +65,18 @@ specs:
   - mne =1.3.0=*_0
   - mne-installer-menus =1.3.0=*_0
   - mne-bids =0.12.0
-  - mne-bids-pipeline =1.0.3
+  - mne-bids-pipeline =1.1.0
   - mne-qt-browser =0.4.0
-  - mne-connectivity =0.4.0
+  - mne-connectivity =0.5.0
   - mne-faster =1.1.0
   - mne-nirs =0.5.0
   - mne-realtime =0.2.0
   - mne-features =0.2.1
   - mne-rsa =0.8
   - mne-ari =0.1.2
-  - mne-kit-gui =1.0.1
+  - mne-kit-gui =1.1.0
   - mne-icalabel =0.4  # [not win]
-  - autoreject =0.4.0
+  - autoreject =0.4.1
   - pyprep =0.4.2
   - openmeeg =2.5.5
   # Python
@@ -127,7 +129,7 @@ specs:
   - ipympl
   - seaborn
   - plotly
-  - vtk =9.2.2
+  - vtk =9.2.6
   # Temporary
   # for VS Code compatibility: https://github.com/microsoft/vscode-jupyter/issues/8552#issuecomment-1263940999
   - ipywidgets <8
@@ -135,6 +137,7 @@ specs:
 condarc:
   channels:
     - conda-forge
+    # - pytorch  # [win]
   channel_priority: strict
   allow_other_channels: False
-  env_prompt: "(mne-1.3.0_0) "
+  env_prompt: "(mne-1.3.0_1) "

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -32,6 +32,7 @@ class Package:
 allowed_outdated: set[str] = {
     'python',  # 3.11 is out, but we don't have all deps available yet
     'ipywidgets',  # temporary, compatibility with VScode
+    'vtk',  # 9.2.6 causes conflicts as of 2023/02/21
 }
 packages: list[Package] = []
 

--- a/tools/run_constructor.sh
+++ b/tools/run_constructor.sh
@@ -4,6 +4,6 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && 
 source ${SCRIPT_DIR}/extract_version.sh
 export PYTHONUTF8=1
 # enforce UTF-8 encoding when reading files even on Windows
-echo "Running constructor recipe ${RECIPE_DIR}"
+echo "Running constructor recipe ${RECIPE_DIR} in verbose mode"
 # PLATFORM_ARG and EXE_ARG can be used for building macOS ARM64 on Intel
-constructor ${PLATFORM_ARG} ${EXE_ARG} ${RECIPE_DIR}
+constructor -v ${PLATFORM_ARG} ${EXE_ARG} ${RECIPE_DIR}


### PR DESCRIPTION
Separate dep updates and boilerplate `_1` stuff from #168 and #173, and also make sure the installers build with the current stack