### PR TITLE
ENH: Bump versions

### DIFF
--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -77,7 +77,7 @@ specs:
   - mne-ari =0.1.2
   - mne-kit-gui =1.1.0
   - mne-icalabel =0.4  # [not win]
-  - mne-gui-addons =0.2.0
+  - mne-gui-addons =0.1.0
   - autoreject =0.4.1
   - pyriemann =0.4
   - pyprep =0.4.2

--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -96,7 +96,7 @@ specs:
   - spyder =5.4.3
   - darkdetect =0.8.0
   - qdarkstyle =3.1
-  - numba =0.56.4  # TODO: need https://github.com/conda-forge/numba-feedstock/pull/115 for 3.11
+  - numba =0.56.4  # TODO: for 3.11 need https://github.com/conda-forge/numba-feedstock/pull/115
   # Excel I/O
   - openpyxl =3.1.2
   - xlrd =2.0.1

--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -72,7 +72,7 @@ specs:
   - mne-faster =1.1.0
   - mne-nirs =0.5.0
   - mne-realtime =0.2.0
-  - mne-features =0.2.1  # TODO: requires numba
+  - mne-features =0.2.1
   - mne-rsa =0.8
   - mne-ari =0.1.2
   - mne-kit-gui =1.1.0
@@ -109,8 +109,8 @@ specs:
   - dcm2niix =1.0.20230411
   # Time-frequency analysis
   - pactools =0.3.1
-  - tensorpac =0.6.5  # TODO: requires numba
-  - emd =0.5.5  # TODO: wait for a new release because https://github.com/conda-forge/emd-feedstock/pull/8 can't (easily) overcome the setup.py version pin
+  - tensorpac =0.6.5
+  - emd =0.5.5  # TODO: for 3.11 wait for a new release because https://github.com/conda-forge/emd-feedstock/pull/8 can't (easily) overcome the setup.py version pin
   - neurodsp =2.2.0
   - bycycle =1.0.0
   - fooof =1.0.0
@@ -120,8 +120,8 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2022.4.0
   # sleep staging
-  - sleepecg =0.5.4  # TODO: wait for numba, then restart and wait for https://github.com/conda-forge/sleepecg-feedstock/pull/20
-  - yasa =0.6.3  # TODO: wait for sleepecg and tensorpac
+  - sleepecg =0.5.4  # TODO: for 3.11 wait for numba, then restart and wait for https://github.com/conda-forge/sleepecg-feedstock/pull/20
+  - yasa =0.6.3  # TODO: for 3.11 wait for sleepecg
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.4
   # GitHub client, https://cli.github.com

--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -67,7 +67,7 @@ specs:
   # - mne-installer-menus =1.3.1=*_0
   - mne-bids =0.12.0
   - mne-bids-pipeline =1.2.0
-  # - mne-qt-browser =0.5.0  # TODO: wait for https://github.com/conda-forge/mne-qt-browser-feedstock/pull/23
+  - mne-qt-browser =0.5.0
   - mne-connectivity =0.5.0
   - mne-faster =1.1.0
   - mne-nirs =0.5.0
@@ -104,7 +104,8 @@ specs:
   - pingouin =0.5.3
   - pycircstat =0.0.2
   # MRI
-  - fsleyes =1.6.1
+  - fsleyes =1.6.1 # [not win]
+  - fsleyes =1.6.0 # [win]
   - dcm2niix =1.0.20230411
   # Time-frequency analysis
   - pactools =0.3.1

--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -67,12 +67,12 @@ specs:
   # - mne-installer-menus =1.3.1=*_0
   - mne-bids =0.12.0
   - mne-bids-pipeline =1.2.0
-  - mne-qt-browser =0.5.0
+  # - mne-qt-browser =0.5.0  # TODO: wait for https://github.com/conda-forge/mne-qt-browser-feedstock/pull/23
   - mne-connectivity =0.5.0
   - mne-faster =1.1.0
   - mne-nirs =0.5.0
   - mne-realtime =0.2.0
-  - mne-features =0.2.1
+  # - mne-features =0.2.1  # TODO: requires numba
   - mne-rsa =0.8
   - mne-ari =0.1.2
   - mne-kit-gui =1.1.0
@@ -96,8 +96,7 @@ specs:
   - spyder =5.4.3
   - darkdetect =0.8.0
   - qdarkstyle =3.1
-  # TODO: Enable this once 3.11 packages land
-  # - numba
+  # - numba  # TODO: wait for https://github.com/conda-forge/numba-feedstock/pull/115
   # Excel I/O
   - openpyxl =3.1.2
   - xlrd =2.0.1
@@ -109,8 +108,8 @@ specs:
   - dcm2niix =1.0.20230411
   # Time-frequency analysis
   - pactools =0.3.1
-  - tensorpac =0.6.5
-  - emd =0.5.5
+  # - tensorpac =0.6.5  # TODO: requires numba
+  # - emd =0.5.5  # TODO: wait for a new release because https://github.com/conda-forge/emd-feedstock/pull/8 can't (easily) overcome the setup.py version pin
   - neurodsp =2.2.0
   - bycycle =1.0.0
   - fooof =1.0.0
@@ -120,8 +119,8 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2022.4.0
   # sleep staging
-  - sleepecg =0.5.4
-  - yasa =0.6.3
+  # - sleepecg =0.5.4  # TODO: wait for numba, then restart and wait for https://github.com/conda-forge/sleepecg-feedstock/pull/20
+  # - yasa =0.6.3  # TODO: wait for sleepecg and tensorpac
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.4
   # GitHub client, https://cli.github.com

--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -72,7 +72,7 @@ specs:
   - mne-faster =1.1.0
   - mne-nirs =0.5.0
   - mne-realtime =0.2.0
-  # - mne-features =0.2.1  # TODO: requires numba
+  - mne-features =0.2.1  # TODO: requires numba
   - mne-rsa =0.8
   - mne-ari =0.1.2
   - mne-kit-gui =1.1.0
@@ -83,7 +83,7 @@ specs:
   - pyprep =0.4.2
   - openmeeg =2.5.6
   # Python
-  - python =3.11.3
+  - python =3.10.10
   - pip =23.1.2
   - conda =23.3.1
   - mamba =1.4.2
@@ -96,7 +96,7 @@ specs:
   - spyder =5.4.3
   - darkdetect =0.8.0
   - qdarkstyle =3.1
-  # - numba  # TODO: wait for https://github.com/conda-forge/numba-feedstock/pull/115
+  - numba =0.56.4  # TODO: need https://github.com/conda-forge/numba-feedstock/pull/115 for 3.11
   # Excel I/O
   - openpyxl =3.1.2
   - xlrd =2.0.1
@@ -109,8 +109,8 @@ specs:
   - dcm2niix =1.0.20230411
   # Time-frequency analysis
   - pactools =0.3.1
-  # - tensorpac =0.6.5  # TODO: requires numba
-  # - emd =0.5.5  # TODO: wait for a new release because https://github.com/conda-forge/emd-feedstock/pull/8 can't (easily) overcome the setup.py version pin
+  - tensorpac =0.6.5  # TODO: requires numba
+  - emd =0.5.5  # TODO: wait for a new release because https://github.com/conda-forge/emd-feedstock/pull/8 can't (easily) overcome the setup.py version pin
   - neurodsp =2.2.0
   - bycycle =1.0.0
   - fooof =1.0.0
@@ -120,8 +120,8 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2022.4.0
   # sleep staging
-  # - sleepecg =0.5.4  # TODO: wait for numba, then restart and wait for https://github.com/conda-forge/sleepecg-feedstock/pull/20
-  # - yasa =0.6.3  # TODO: wait for sleepecg and tensorpac
+  - sleepecg =0.5.4  # TODO: wait for numba, then restart and wait for https://github.com/conda-forge/sleepecg-feedstock/pull/20
+  - yasa =0.6.3  # TODO: wait for sleepecg and tensorpac
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.4
   # GitHub client, https://cli.github.com
@@ -134,7 +134,8 @@ specs:
   - ipympl =0.9.3
   - seaborn =0.12.2
   - plotly =5.14.1
-  - vtk =9.2.6
+  - vtk =9.2.6  # [arm64 or not osx]
+  - vtk =9.2.5  # [osx and not arm64]
   - git =2.40.1  # [win]
   - make =4.3  # [win]
   - ipywidgets =8.0.6

--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -49,7 +49,7 @@ channels:
   # conda-forge doesn't provide pytorch packages for Windows
   # - pytorch  # [win]
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: COMMENT OUT BEFORE RELEASE! ⛔️ ⛔️ ⛔️
-  # - conda-forge/label/mne_dev
+  - conda-forge/label/mne_dev
   # - conda-forge/label/mne-bids_dev
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: COMMENT OUT BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 
@@ -57,14 +57,14 @@ specs:
   # MNE ecosystem
 
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
-  # - mne =1.2dev0=*_20221007
-  # - mne-installer-menus =1.2dev0=*_20221007
+  - mne =1.4dev0=*_20230503
+  - mne-installer-menus =1.4dev0=*_20230503
   # - mne-bids =0.11dev0=*_20221007
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 
   # TODO: Once 1.4 is actually released, bump these
-  - mne =1.3.1=*_0
-  - mne-installer-menus =1.3.1=*_0
+  # - mne =1.3.1=*_0
+  # - mne-installer-menus =1.3.1=*_0
   - mne-bids =0.12.0
   - mne-bids-pipeline =1.2.0
   - mne-qt-browser =0.5.0
@@ -77,12 +77,13 @@ specs:
   - mne-ari =0.1.2
   - mne-kit-gui =1.1.0
   - mne-icalabel =0.4  # [not win]
+  - mne-gui-addons =0.2.0
   - autoreject =0.4.1
   - pyriemann =0.4
   - pyprep =0.4.2
   - openmeeg =2.5.6
   # Python
-  - python =3.10.8
+  - python =3.11.3
   - pip =23.1.2
   - conda =23.3.1
   - mamba =1.4.2
@@ -95,15 +96,16 @@ specs:
   - spyder =5.4.3
   - darkdetect =0.8.0
   - qdarkstyle =3.1
+  # TODO: Enable this once 3.11 packages land
+  # - numba
   # Excel I/O
-  - openpyxl =3.1.1
+  - openpyxl =3.1.2
   - xlrd =2.0.1
   # Statistics
   - pingouin =0.5.3
   - pycircstat =0.0.2
   # MRI
-  - fsleyes =1.6.1 # [not win]
-  - fsleyes =1.6.0 # [win]
+  - fsleyes =1.6.1
   - dcm2niix =1.0.20230411
   # Time-frequency analysis
   - pactools =0.3.1
@@ -132,8 +134,7 @@ specs:
   - ipympl =0.9.3
   - seaborn =0.12.2
   - plotly =5.14.1
-  - vtk =9.2.6  # [arm64 or not osx]
-  - vtk =9.2.5  # [osx and not arm64]
+  - vtk =9.2.6
   - git =2.40.1  # [win]
   - make =4.3  # [win]
   - ipywidgets =8.0.6

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -42,7 +42,7 @@ if not sys.platform.startswith('win'):
     assert fname.is_file()
     os.remove(fname)
     mne.viz.close_3d_figure(fig)
-    assert '.BackgroundPlotter' in repr(plotter), repr(plotter)
+    assert 'BackgroundPlotter' in repr(plotter), repr(plotter)
 
 # mne-qt-browser
 print('Running mne-qt-browser tests')

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -7,7 +7,7 @@ import mne_connectivity
 import mne_faster
 import mne_nirs
 import mne_realtime
-# import mne_features
+import mne_features
 import mne_rsa
 import mne_microstates
 import mne_ari
@@ -24,19 +24,18 @@ import xlrd
 import pingouin
 import pycircstat
 import pactools
-# import numba
-# import tensorpac
-# import emd
+import numba
+import tensorpac
+import emd
 import neurodsp
 import bycycle
 import fooof
 import openneuro
-# import sleepecg
-# import yasa
+import sleepecg
+import yasa
 import neurokit2
 import questionary
 import matplotlib
 import seaborn
 import plotly
 import pqdm
-# import numba

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -7,7 +7,7 @@ import mne_connectivity
 import mne_faster
 import mne_nirs
 import mne_realtime
-import mne_features
+# import mne_features
 import mne_rsa
 import mne_microstates
 import mne_ari
@@ -24,17 +24,19 @@ import xlrd
 import pingouin
 import pycircstat
 import pactools
-import tensorpac
-import emd
+# import numba
+# import tensorpac
+# import emd
 import neurodsp
 import bycycle
 import fooof
 import openneuro
-import sleepecg
-import yasa
+# import sleepecg
+# import yasa
 import neurokit2
 import questionary
 import matplotlib
 import seaborn
 import plotly
 import pqdm
+# import numba

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -19,12 +19,12 @@ import pyprep
 import pycrostates
 import darkdetect
 import qdarkstyle
+import numba
 import openpyxl
 import xlrd
 import pingouin
 import pycircstat
 import pactools
-import numba
 import tensorpac
 import emd
 import neurodsp

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -30,7 +30,9 @@ class Package:
 
 
 allowed_outdated: set[str] = {
-    'fsleyes',  # 2023/04/05: some unknown conflict on Windows
+    'python',  # 3.11 is out, but we don't have all deps available yet
+    'fsleyes',  # 2023/04/05: Windows binaries didn't upload
+    'vtk',  # 2023/04/05: some unknown conflict on non-arm macOS
 }
 packages: list[Package] = []
 

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -30,9 +30,6 @@ class Package:
 
 
 allowed_outdated: set[str] = {
-    'python',  # 3.11 is out, but we don't have all deps available yet
-    'fsleyes',  # 2023/04/05: some unknown conflict on Windows
-    'vtk',  # 2023/04/05: some unknown conflict on arm
 }
 packages: list[Package] = []
 

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -30,6 +30,7 @@ class Package:
 
 
 allowed_outdated: set[str] = {
+    'fsleyes',  # 2023/04/05: some unknown conflict on Windows
 }
 packages: list[Package] = []
 


### PR DESCRIPTION
- Tries 3.11
- Adds stub for Numba where we should add it once it lands
- Needs latest dev version https://github.com/conda-forge/mne-feedstock/pull/118 to land and hit CDNs (this one does not require numba)
- By that time, `mne-gui-addons` should also be in CDNs, which I've added here
- I'm trying to remove some pins for `fsleyes` and `vtk` to see if they're magically resolved

First run will undoubtedly fail, I'll restart in an hour or two