### PR TITLE
Bump pycrostates version

### DIFF
--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -90,7 +90,7 @@ specs:
   - openblas =0.3.23
   - jupyter =1.0.0
   - jupyterlab =3.6.3
-  - ipykernel =6.22.0
+  - ipykernel =6.23.0
   - nb_conda_kernels =2.3.1
   - spyder-kernels =2.4.3
   - spyder =5.4.3

--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -49,7 +49,7 @@ channels:
   # conda-forge doesn't provide pytorch packages for Windows
   # - pytorch  # [win]
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: COMMENT OUT BEFORE RELEASE! ⛔️ ⛔️ ⛔️
-  - conda-forge/label/mne_dev
+  # - conda-forge/label/mne_dev
   # - conda-forge/label/mne-bids_dev
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: COMMENT OUT BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 
@@ -57,14 +57,13 @@ specs:
   # MNE ecosystem
 
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
-  - mne =1.4dev0=*_20230503
-  - mne-installer-menus =1.4dev0=*_20230503
+  # - mne =1.4dev0=*_20230503
+  # - mne-installer-menus =1.4dev0=*_20230503
   # - mne-bids =0.11dev0=*_20221007
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 
-  # TODO: Once 1.4 is actually released, bump these
-  # - mne =1.3.1=*_0
-  # - mne-installer-menus =1.3.1=*_0
+  - mne =1.4.0=*_0
+  - mne-installer-menus =1.4.0=*_0
   - mne-bids =0.12.0
   - mne-bids-pipeline =1.2.0
   - mne-qt-browser =0.5.0

--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -116,7 +116,7 @@ specs:
   - fooof =1.0.0
   # Microstates
   - mne-microstates =0.3.0
-  - pycrostates =0.2.0
+  - pycrostates =0.3.0
   # OpenNeuro.org data access
   - openneuro-py =2022.4.0
   # sleep staging


### PR DESCRIPTION
Version 0.3.0 released with improvements + compatibility for recent version of matplotlib and python.
Should be available today on conda-forge: https://github.com/conda-forge/pycrostates-feedstock/pull/9