### PR TITLE
BUG: Add tests for setuptools_scm versions, fix mne-qt-browser

### DIFF
--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -88,8 +88,8 @@ specs:
   - mamba =1.4.2
   - openblas =0.3.23
   - jupyter =1.0.0
-  - jupyterlab =3.6.3
-  - ipykernel =6.23.0
+  - jupyterlab =4.0.0
+  - ipykernel =6.23.1
   - nb_conda_kernels =2.3.1
   - spyder-kernels =2.4.3
   - spyder =5.4.3

--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -1,4 +1,4 @@
-version: 1.4.0_0
+version: 1.4.0_1
 name: MNE-Python
 company: MNE-Python Developers
 # When the version above changes to a new major/minor, it needs to be updated
@@ -18,17 +18,17 @@ initialize_by_default: False
 register_python_default: False
 
 # default_prefix will be ignored by macOS .pkg installer!
-default_prefix: ${HOME}/mne-python/1.4.0_0                          # [linux]
-default_prefix: "%USERPROFILE%\\mne-python\\1.4.0_0"                # [win]
-default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.4.0_0"   # [win]
-default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.4.0_0"  # [win]
+default_prefix: ${HOME}/mne-python/1.4.0_1                          # [linux]
+default_prefix: "%USERPROFILE%\\mne-python\\1.4.0_1"                # [win]
+default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.4.0_1"   # [win]
+default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.4.0_1"  # [win]
 
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
-installer_filename: MNE-Python-1.4.0_0-macOS_Intel.pkg  # [osx and not arm64]
-installer_filename: MNE-Python-1.4.0_0-macOS_M1.pkg     # [osx and arm64]
-installer_filename: MNE-Python-1.4.0_0-Windows.exe      # [win]
-installer_filename: MNE-Python-1.4.0_0-Linux.sh         # [linux]
+installer_filename: MNE-Python-1.4.0_1-macOS_Intel.pkg  # [osx and not arm64]
+installer_filename: MNE-Python-1.4.0_1-macOS_M1.pkg     # [osx and arm64]
+installer_filename: MNE-Python-1.4.0_1-Windows.exe      # [win]
+installer_filename: MNE-Python-1.4.0_1-Linux.sh         # [linux]
 
 post_install: ../../assets/post_install_macOS.sh        # [osx]
 post_install: ../../assets/post_install_linux.sh        # [linux]
@@ -145,4 +145,4 @@ condarc:
     - conda-forge
   channel_priority: strict
   allow_other_channels: False
-  env_prompt: "(mne-1.4.0_0) "
+  env_prompt: "(mne-1.4.0_1) "

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,11 +1,21 @@
 import platform
 
+
+def check_min_version(package, min_version):
+    from packaging.version import parse
+    assert parse(package.__version__) >= parse(min_version), f'{package}: got {package.__version__} wanted {min_version}'
+
+
 import mne
+check_min_version(mne, '1.4')
 import mne_bids
 import mne_bids_pipeline
+check_min_version(mne_bids_pipeline, '1.2')
 import mne_connectivity
 import mne_faster
 import mne_nirs
+import mne_qt_browser
+check_min_version(mne_qt_browser, '0.5.0')
 import mne_realtime
 import mne_features
 import mne_rsa


### PR DESCRIPTION
To help check https://github.com/mne-tools/mne-qt-browser/issues/165

Eventually we could probably assert actual version numbers based on our pinning file and such. But for now this is good enough I think

Should fail until https://github.com/conda-forge/mne-qt-browser-feedstock/pull/24 is in and CDNs update