### PR TITLE
MAINT: Bump to 1.4.2

### DIFF
--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -77,6 +77,7 @@ specs:
   - mne-kit-gui =1.1.0
   - mne-icalabel =0.4  # [not win]
   - mne-gui-addons =0.1.0
+  - traitsui =7.4.3  # mayavi not 8.0 compatible
   - autoreject =0.4.2
   - pyriemann =0.4
   - pyprep =0.4.2

--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -84,7 +84,7 @@ specs:
   # Python
   - python =3.10.10
   - pip =23.1.2
-  - conda =23.5.0
+  - conda =23.3.1
   - mamba =1.4.2
   - openblas =0.3.23
   - jupyter =1.0.0

--- a/recipes/mne-python_1.4/construct.yaml
+++ b/recipes/mne-python_1.4/construct.yaml
@@ -1,4 +1,4 @@
-version: 1.4.0_1
+version: 1.4.2_0
 name: MNE-Python
 company: MNE-Python Developers
 # When the version above changes to a new major/minor, it needs to be updated
@@ -18,17 +18,17 @@ initialize_by_default: False
 register_python_default: False
 
 # default_prefix will be ignored by macOS .pkg installer!
-default_prefix: ${HOME}/mne-python/1.4.0_1                          # [linux]
-default_prefix: "%USERPROFILE%\\mne-python\\1.4.0_1"                # [win]
-default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.4.0_1"   # [win]
-default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.4.0_1"  # [win]
+default_prefix: ${HOME}/mne-python/1.4.2_0                          # [linux]
+default_prefix: "%USERPROFILE%\\mne-python\\1.4.2_0"                # [win]
+default_prefix_domain_user: "%LOCALAPPDATA%\\mne-python\\1.4.2_0"   # [win]
+default_prefix_all_users: "%ALLUSERSPROFILE%\\mne-python\\1.4.2_0"  # [win]
 
 uninstall_name: MNE-Python ${VERSION} (Python ${PYVERSION})
 
-installer_filename: MNE-Python-1.4.0_1-macOS_Intel.pkg  # [osx and not arm64]
-installer_filename: MNE-Python-1.4.0_1-macOS_M1.pkg     # [osx and arm64]
-installer_filename: MNE-Python-1.4.0_1-Windows.exe      # [win]
-installer_filename: MNE-Python-1.4.0_1-Linux.sh         # [linux]
+installer_filename: MNE-Python-1.4.2_0-macOS_Intel.pkg  # [osx and not arm64]
+installer_filename: MNE-Python-1.4.2_0-macOS_M1.pkg     # [osx and arm64]
+installer_filename: MNE-Python-1.4.2_0-Windows.exe      # [win]
+installer_filename: MNE-Python-1.4.2_0-Linux.sh         # [linux]
 
 post_install: ../../assets/post_install_macOS.sh        # [osx]
 post_install: ../../assets/post_install_linux.sh        # [linux]
@@ -62,10 +62,10 @@ specs:
   # - mne-bids =0.11dev0=*_20221007
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 
-  - mne =1.4.0=*_0
-  - mne-installer-menus =1.4.0=*_0
+  - mne =1.4.2=*_0
+  - mne-installer-menus =1.4.2=*_0
   - mne-bids =0.12.0
-  - mne-bids-pipeline =1.2.0
+  - mne-bids-pipeline =1.3.0
   - mne-qt-browser =0.5.0
   - mne-connectivity =0.5.0
   - mne-faster =1.1.0
@@ -77,25 +77,25 @@ specs:
   - mne-kit-gui =1.1.0
   - mne-icalabel =0.4  # [not win]
   - mne-gui-addons =0.1.0
-  - autoreject =0.4.1
+  - autoreject =0.4.2
   - pyriemann =0.4
   - pyprep =0.4.2
   - openmeeg =2.5.6
   # Python
   - python =3.10.10
   - pip =23.1.2
-  - conda =23.3.1
+  - conda =23.5.0
   - mamba =1.4.2
   - openblas =0.3.23
   - jupyter =1.0.0
-  - jupyterlab =4.0.0
+  - jupyterlab =4.0.1
   - ipykernel =6.23.1
   - nb_conda_kernels =2.3.1
   - spyder-kernels =2.4.3
   - spyder =5.4.3
   - darkdetect =0.8.0
   - qdarkstyle =3.1
-  - numba =0.56.4  # TODO: for 3.11 need https://github.com/conda-forge/numba-feedstock/pull/115
+  - numba =0.57.0
   # Excel I/O
   - openpyxl =3.1.2
   - xlrd =2.0.1
@@ -109,7 +109,7 @@ specs:
   # Time-frequency analysis
   - pactools =0.3.1
   - tensorpac =0.6.5
-  - emd =0.5.5  # TODO: for 3.11 wait for a new release because https://github.com/conda-forge/emd-feedstock/pull/8 can't (easily) overcome the setup.py version pin
+  - emd =0.6.2
   - neurodsp =2.2.0
   - bycycle =1.0.0
   - fooof =1.0.0
@@ -119,7 +119,7 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2022.4.0
   # sleep staging
-  - sleepecg =0.5.4  # TODO: for 3.11 wait for numba, then restart and wait for https://github.com/conda-forge/sleepecg-feedstock/pull/20
+  - sleepecg =0.5.5  # TODO: for 3.11 wait for numba, then restart and wait for https://github.com/conda-forge/sleepecg-feedstock/pull/20
   - yasa =0.6.3  # TODO: for 3.11 wait for sleepecg
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.4
@@ -135,7 +135,7 @@ specs:
   - plotly =5.14.1
   - vtk =9.2.6  # [arm64 or not osx]
   - vtk =9.2.5  # [osx and not arm64]
-  - git =2.40.1  # [win]
+  - git =2.41.0  # [win]
   - make =4.3  # [win]
   - ipywidgets =8.0.6
 
@@ -145,4 +145,4 @@ condarc:
     - conda-forge
   channel_priority: strict
   allow_other_channels: False
-  env_prompt: "(mne-1.4.0_1) "
+  env_prompt: "(mne-1.4.2_0) "

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -34,6 +34,7 @@ allowed_outdated: set[str] = {
     'fsleyes',  # 2023/04/05: Windows binaries didn't upload
     'vtk',  # 2023/04/05: some unknown conflict on non-arm macOS
     'conda',  # 203/06/07: breaks/conflicts for some unknown reason
+    'traitsui',  # mayavi not 8.0 compatible
 }
 packages: list[Package] = []
 

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -33,6 +33,7 @@ allowed_outdated: set[str] = {
     'python',  # 3.11 is out, but we don't have all deps available yet
     'fsleyes',  # 2023/04/05: Windows binaries didn't upload
     'vtk',  # 2023/04/05: some unknown conflict on non-arm macOS
+    'conda',  # 203/06/07: breaks/conflicts for some unknown reason
 }
 packages: list[Package] = []
 

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -84,14 +84,14 @@ for package in packages:
         packaging.version.parse(package.version_spec) <
         packaging.version.parse(package.version_conda_forge)
     ):
+        mismatch = f'{package.version_spec} < {package.version_conda_forge}'
         if package.name in allowed_outdated:
-            print(f'  {package.name.ljust(20)} outdated (allowed '
-                  f'{package.version_spec} < {package.version_conda_forge})')
+            print(f'  {package.name.ljust(20)} ✓ allowed  {mismatch}')
         else:
-            print(f'* {package.name.ljust(20)} OUTDATED')
+            print(f'* {package.name.ljust(20)} ✗ OUTDATED {mismatch}')
             outdated.append(package)
     else:
-        print(f'  {package.name.ljust(20)} up to date')
+        print(f'  {package.name.ljust(20)} ✓')
 
 exit_code = 0
 if not_found:


### PR DESCRIPTION
Can't go to 3.11 yet unless we want to drop `sleepecg` and `yasa` (which needs `sleepecg`) because `sleepecg` needs Tensorflow and that is stalled at the conda end. I have no idea how widely used these packages are so I'm hesitant to remove them since we have included them previously.

Will fail until https://github.com/conda-forge/mne-feedstock/pull/122 lands and hits CDNs, at which point I'll restart CIs. I'll mark for merge-when-green then cut a release and update the MNE website with updated installer links