### PR TITLE
Bump mne-icalabel

### DIFF
--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -64,7 +64,7 @@ specs:
   - pip =23.3.1
   - conda =23.9.0
   - mamba =1.5.2
-  - conda-libmamba-solver =23.9.2
+  - conda-libmamba-solver =23.9.3
   # MNE ecosystem
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
   # - mne =1.4dev0=*_20230503
@@ -92,19 +92,19 @@ specs:
   - traitsui =8.0.0
   - autoreject =0.4.2
   - pyriemann =0.5
-  - pyprep =0.4.2
+  - pyprep =0.4.3
   - openmeeg =2.5.6
   # BLAS
   - openblas =0.3.24
   - libblas =3.9.0=*openblas
   - jupyter =1.0.0
   - jupyterlab =4.0.7
-  - ipykernel =6.25.2
+  - ipykernel =6.26.0
   - nb_conda_kernels =2.3.1
   - spyder-kernels =2.4.4
   - spyder =5.4.5
   - darkdetect =0.8.0
-  - qdarkstyle =3.1
+  - qdarkstyle =3.2
   - numba =0.57.1
   # I/O
   - pyxdf =1.16.4
@@ -130,7 +130,7 @@ specs:
   - openneuro-py =2023.1.0
   # sleep staging
   - sleepecg =0.5.5
-  - tensorflow ==2.12.1=cpu_py311*  # [not win]
+  - tensorflow ==2.13.1=cpu_py311*  # [not win]
   - yasa =0.6.3
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.6
@@ -143,24 +143,24 @@ specs:
   - matplotlib =3.8.0
   - ipympl =0.9.3
   - seaborn =0.13.0
-  - plotly =5.17.0
+  - plotly =5.18.0
   - vtk =9.2.6
   - git =2.42.0  # [win]
   - make =4.3  # [win]
   - ipywidgets =8.1.1
   - pyvista =0.42.3
-  - trame =3.2.7
+  - trame =3.2.8
   - trame-vtk =2.5.9
   - trame-vuetify =2.3.1
   # Development
   - setuptools_scm =8.0.4
-  - pytest =7.4.2
+  - pytest =7.4.3
   - pytest-cov =4.1.0
   - pytest-qt =4.2.0
   - pytest-harvest =1.10.4
   - pre-commit =3.5.0
-  - ruff =0.1.1
-  - black =23.10.0
+  - ruff =0.1.3
+  - black =23.10.1
   - py-spy =0.3.14
   - line_profiler =4.1.1
   - memory_profiler =0.61.0

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -63,8 +63,8 @@ specs:
   - python =3.11.5
   - pip =23.3.1
   - conda =23.9.0
-  - mamba =1.5.2
-  - conda-libmamba-solver =23.9.3
+  - mamba =1.5.3
+  - conda-libmamba-solver =23.11.0
   # MNE ecosystem
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
   # - mne =1.4dev0=*_20230503
@@ -98,7 +98,7 @@ specs:
   - openblas =0.3.24
   - libblas =3.9.0=*openblas
   - jupyter =1.0.0
-  - jupyterlab =4.0.7
+  - jupyterlab =4.0.8
   - ipykernel =6.26.0
   - nb_conda_kernels =2.3.1
   - spyder-kernels =2.4.4
@@ -135,12 +135,12 @@ specs:
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.6
   # GitHub client, https://cli.github.com
-  - gh =2.37.0
+  - gh =2.38.0
   # NeuroSpin needs the following
   - questionary =2.0.1
   - pqdm =0.2.0
   # Viz
-  - matplotlib =3.8.0
+  - matplotlib =3.8.1
   - ipympl =0.9.3
   - seaborn =0.13.0
   - plotly =5.18.0
@@ -149,7 +149,7 @@ specs:
   - make =4.3  # [win]
   - ipywidgets =8.1.1
   - pyvista =0.42.3
-  - trame =3.2.8
+  - trame =3.3.0
   - trame-vtk =2.5.9
   - trame-vuetify =2.3.1
   # Development

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -86,7 +86,7 @@ specs:
   - mne-rsa =0.9
   - mne-ari =0.1.2
   - mne-kit-gui =1.1.0
-  - mne-icalabel =0.4  # [not win]
+  - mne-icalabel =0.5.1
   - mne-gui-addons =0.1.0
   - mne-lsl =1.0.0
   - traitsui =8.0.0

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -104,7 +104,7 @@ specs:
   - spyder-kernels =2.4.4
   - spyder =5.4.5
   - darkdetect =0.8.0
-  - qdarkstyle =3.2
+  - qdarkstyle =3.1
   - numba =0.57.1
   # I/O
   - pyxdf =1.16.4
@@ -130,7 +130,7 @@ specs:
   - openneuro-py =2023.1.0
   # sleep staging
   - sleepecg =0.5.5
-  - tensorflow ==2.13.1=cpu_py311*  # [not win]
+  - tensorflow ==2.12.1=cpu_py311*  # [not win]
   - yasa =0.6.3
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.6

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -25,7 +25,8 @@ class Package:  # noqa: D101
 
 allowed_outdated: set[str] = {
     "python",  # ignore 3.12.0rc3
-    "tensorflow",  # 3.13.1 conflicts with VTK
+    "tensorflow",  # 2.13.1 conflicts with VTK
+    "qdarkstyle",  # 3.2 conflicts with Spyder 5.4.5
 }
 packages: list[Package] = []
 


### PR DESCRIPTION
Version 0.5.1 depends on `onnxruntime` instead of `pytorch`.

Closes #178
Closes #218 