### PR TITLE
Bump pycrostates to 0.4.0

### DIFF
--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -102,7 +102,7 @@ specs:
   - ipykernel =6.26.0
   - nb_conda_kernels =2.3.1
   - spyder-kernels =2.5.0
-  - spyder =5.4.5
+  - spyder =5.5.0
   - darkdetect =0.8.0
   - qdarkstyle =3.1
   - numba =0.58.1
@@ -150,7 +150,7 @@ specs:
   - ipywidgets =8.1.1
   - pyvista =0.42.3
   - trame =3.3.0
-  - trame-vtk =2.5.9
+  - trame-vtk =2.6.0
   - trame-vuetify =2.3.1
   # Development
   - setuptools_scm =8.0.4
@@ -159,7 +159,7 @@ specs:
   - pytest-qt =4.2.0
   - pytest-harvest =1.10.4
   - pre-commit =3.5.0
-  - ruff =0.1.4
+  - ruff =0.1.5
   - black =23.10.1
   - py-spy =0.3.14
   - line_profiler =4.1.1

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -104,7 +104,7 @@ specs:
   - spyder-kernels =2.5.0
   - spyder =5.5.0
   - darkdetect =0.8.0
-  - qdarkstyle =3.1
+  - qdarkstyle =3.2
   - numba =0.58.1
   # I/O
   - pyxdf =1.16.4

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -105,7 +105,7 @@ specs:
   - spyder =5.4.5
   - darkdetect =0.8.0
   - qdarkstyle =3.1
-  - numba =0.57.1
+  - numba =0.58.1
   # I/O
   - pyxdf =1.16.4
   - openpyxl =3.1.2

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -125,7 +125,7 @@ specs:
   - fooof =1.0.0
   # Microstates
   - mne-microstates =0.3.0
-  - pycrostates =0.3.0
+  - pycrostates =0.4.0
   # OpenNeuro.org data access
   - openneuro-py =2023.1.0
   # sleep staging

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -101,7 +101,7 @@ specs:
   - jupyterlab =4.0.8
   - ipykernel =6.26.0
   - nb_conda_kernels =2.3.1
-  - spyder-kernels =2.4.4
+  - spyder-kernels =2.5.0
   - spyder =5.4.5
   - darkdetect =0.8.0
   - qdarkstyle =3.1

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -26,7 +26,6 @@ class Package:  # noqa: D101
 allowed_outdated: set[str] = {
     "python",  # ignore 3.12.0rc3
     "tensorflow",  # 2.13.1 conflicts with VTK
-    "qdarkstyle",  # 3.2 conflicts with Spyder 5.4.5
 }
 packages: list[Package] = []
 


### PR DESCRIPTION
Required for compatibility with MNE 1.6
Feedstock update: https://github.com/conda-forge/pycrostates-feedstock/pull/11