### PR TITLE
MAINT: Bump to 1.6.0

### DIFF
--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -85,7 +85,7 @@ specs:
   - mne-features =0.3
   - mne-rsa =0.9
   - mne-ari =0.1.2
-  - mne-kit-gui =1.1.0
+  - mne-kit-gui =1.2.0
   - mne-icalabel =0.5.1
   - mne-gui-addons =0.1.0
   - mne-lsl =1.1.0

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -71,8 +71,8 @@ specs:
   # - mne-installer-menus =1.4dev0=*_20230503
   # - mne-bids =0.11dev0=*_20221007
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
-  - mne =1.5.1=*_0
-  - mne-installer-menus =1.5.1=*_0
+  - mne =1.6.0=*_0
+  - mne-installer-menus =1.6.0=*_0
   # For testing purposes with build_local.sh, you can comment out all deps
   # below for speed, and change mne to mne-base above
   - mne-bids =0.14

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -80,7 +80,7 @@ specs:
   - mne-qt-browser =0.6.1
   - mne-connectivity =0.5.0
   - mne-faster =1.1.0
-  - mne-nirs =0.5.0
+  - mne-nirs =0.6.0
   - mne-realtime =0.3.0
   - mne-features =0.3
   - mne-rsa =0.9

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -179,7 +179,7 @@ specs:
   - python-graphviz =0.20.1
   - selenium =4.15.2
   - sphinx-design =0.5.0
-  - sphinx-gallery =0.14.0
+  - sphinx-gallery =0.15.0
   - sphinxcontrib-bibtex =2.6.1
   - sphinx-copybutton =0.5.2
   - sphinxcontrib-youtube =1.4.1

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -27,6 +27,7 @@ allowed_outdated: set[str] = {
     "python",  # ignore 3.12.0rc3
     "tensorflow",  # 2.13.1 conflicts with VTK
     "graphviz",  # conflicts with VTK
+    "openblas",  # not going to mess with it right at release time
     "pydata-sphinx-theme",  # haven't updated to latest version in our conf.py
 }
 packages: list[Package] = []


### PR DESCRIPTION
Will fail until https://github.com/conda-forge/mne-feedstock/pull/126 lands and CDNs update