### PR TITLE
Add more logging output to Apple certificate workflow and ensure OpenSSL can handle our Developer certificates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-      - macos-certs
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+      - macos-certs
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           environment-file: environment.yml
       - run: ./tools/extract_version.sh
       - run: ./tools/macos_install_certificates.sh
-        # if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           APPLICATION_CERT_BASE64: ${{ secrets.APPLE_APPLICATION_CERT_BASE64 }}
           APPLICATION_CERT_PASSWORD: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           environment-file: environment.yml
       - run: ./tools/extract_version.sh
       - run: ./tools/macos_install_certificates.sh
-        if: ${{ github.event_name != 'pull_request' }}
+        # if: ${{ github.event_name != 'pull_request' }}
         env:
           APPLICATION_CERT_BASE64: ${{ secrets.APPLE_APPLICATION_CERT_BASE64 }}
           APPLICATION_CERT_PASSWORD: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -8,7 +8,7 @@ exec 2>&1  # redirect stderr to stdout, so error messages show up in GH Actions 
 APPLICATION_CERT_PATH=$RUNNER_TEMP/application_cert.p12
 INSTALLER_CERT_PATH=$RUNNER_TEMP/installer_cert.p12
 KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-
+OPENSSL=/usr/bin/openssl  # could also just use "openssl" to use the conda-forge one
 # import certificates from secrets
 echo "🏃 Retrieving our Developer certificates from GH secrets …"
 echo -n "$APPLICATION_CERT_BASE64" | base64 --decode --output $APPLICATION_CERT_PATH
@@ -16,10 +16,9 @@ echo -n "$INSTALLER_CERT_BASE64" | base64 --decode --output $INSTALLER_CERT_PATH
 echo "✅ Done retrieving our Developer certificates from GH secrets."
 
 echo "🏃 Displaying information on our Developer certificates …"
-echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
-echo "Using OpenSSL:" `openssl version`
-openssl pkcs12 -legacy -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
-openssl pkcs12 -legacy -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
+echo "Using OpenSSL:" `$OPENSSL version`
+$OPENSSL pkcs12 -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
+$OPENSSL pkcs12 -legacy -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
 echo "✅ Done displaying information on our Developer certificates."
 
 # create temporary keychain
@@ -48,10 +47,9 @@ echo "✅ Done installing Apple certificates."
 
 # ensure we're going to import the correct developer certificates into keychain
 echo "🏃 Running sanity check on our Developer certificates before importing …"
-echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
-echo "Using OpenSSL:" `openssl version`
-openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
-openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
+echo "Using OpenSSL:" `$OPENSSL version`
+$OPENSSL pkcs12 -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
+$OPENSSL pkcs12 -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
 echo "✅ Done running sanity check on our Developer certificates before importing."
 
 # import developer certificates

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -16,8 +16,8 @@ echo -n "$INSTALLER_CERT_BASE64" | base64 --decode --output $INSTALLER_CERT_PATH
 echo "✅ Done retrieving our Developer certificates from GH secrets."
 
 echo "🏃 Displaying information on our Developer certificates …"
-openssl pkcs12 -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
-openssl pkcs12 -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
+/usr/bin/openssl pkcs12 -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
+/usr/bin/openssl pkcs12 -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
 echo "✅ Done displaying information on our Developer certificates."
 
 # create temporary keychain

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -16,8 +16,8 @@ echo -n "$INSTALLER_CERT_BASE64" | base64 --decode --output $INSTALLER_CERT_PATH
 echo "✅ Done retrieving our Developer certificates from GH secrets."
 
 echo "🏃 Displaying information on our Developer certificates …"
-openssl -legacy pkcs12 -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
-openssl -legacy pkcs12 -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
+openssl pkcs12 -legacy -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
+openssl pkcs12 -legacy -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
 echo "✅ Done displaying information on our Developer certificates."
 
 # create temporary keychain

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -9,10 +9,10 @@ INSTALLER_CERT_PATH=$RUNNER_TEMP/installer_cert.p12
 KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
 # import certificates from secrets
-echo "🏃 Retrieving Developer certificates from GH secrets …"
+echo "🏃 Retrieving our Developer certificates from GH secrets …"
 echo -n "$APPLICATION_CERT_BASE64" | base64 --decode --output $APPLICATION_CERT_PATH
 echo -n "$INSTALLER_CERT_BASE64" | base64 --decode --output $INSTALLER_CERT_PATH
-echo "✅ Done retrieving Developer certificates from GH secrets."
+echo "✅ Done retrieving our Developer certificates from GH secrets."
 
 # create temporary keychain
 echo "🏃 Creating temporary keychain …"

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -13,7 +13,7 @@ echo -n "$APPLICATION_CERT_BASE64" | base64 --decode --output $APPLICATION_CERT_
 echo -n "$INSTALLER_CERT_BASE64" | base64 --decode --output $INSTALLER_CERT_PATH
 
 # create temporary keychain
-echo "🏃 Creating temporary keychains …"
+echo "🏃 Creating temporary keychain …"
 security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
 security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -18,7 +18,7 @@ echo "✅ Done retrieving our Developer certificates from GH secrets."
 echo "🏃 Displaying information on our Developer certificates …"
 echo "Using OpenSSL:" `$OPENSSL version`
 $OPENSSL pkcs12 -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
-$OPENSSL pkcs12 -legacy -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
+$OPENSSL pkcs12 -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
 echo "✅ Done displaying information on our Developer certificates."
 
 # create temporary keychain

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -8,9 +8,11 @@ APPLICATION_CERT_PATH=$RUNNER_TEMP/application_cert.p12
 INSTALLER_CERT_PATH=$RUNNER_TEMP/installer_cert.p12
 KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
-# import certificatefrom secrets
+# import certificates from secrets
+echo "🏃 Retrieving Developer certificates from GH secrets …"
 echo -n "$APPLICATION_CERT_BASE64" | base64 --decode --output $APPLICATION_CERT_PATH
 echo -n "$INSTALLER_CERT_BASE64" | base64 --decode --output $INSTALLER_CERT_PATH
+echo "✅ Done retrieving Developer certificates from GH secrets."
 
 # create temporary keychain
 echo "🏃 Creating temporary keychain …"

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -41,6 +41,7 @@ echo "✅ Done installing Apple certificates."
 # ensure we're going to import the correct developer certificates into keychain
 echo "🏃 Running sanity check on our Developer certificates before importing …"
 echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
+echo "Using OpenSSL:" `openssl version`
 openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
 openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
 echo "✅ Done running sanity check on our Developer certificates before importing."

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -17,7 +17,7 @@ echo "🏃 Creating temporary keychain …"
 security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
 security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-echo "✅ Done creating temporary keychains."
+echo "✅ Done creating temporary keychain."
 
 # download Apple certificates
 echo "🏃 Downloading Apple certificates …"

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eo pipefail
+exec 2>&1  # redirect stderr to stdout, so error messages show up in GH Actions logs
 
 # Based on https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
 # create variables
@@ -42,8 +43,8 @@ echo "✅ Done installing Apple certificates."
 echo "🏃 Running sanity check on our Developer certificates before importing …"
 echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
 echo "Using OpenSSL:" `openssl version`
-openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH  #| grep friendlyName
-openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH  #| grep friendlyName
+openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
+openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
 echo "✅ Done running sanity check on our Developer certificates before importing."
 
 # import developer certificates

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -43,8 +43,8 @@ echo "✅ Done installing Apple certificates."
 echo "🏃 Running sanity check on our Developer certificates before importing …"
 echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
 echo "Using OpenSSL:" `openssl version`
-openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
-openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
+openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH #| grep friendlyName
+openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH #| grep friendlyName
 echo "✅ Done running sanity check on our Developer certificates before importing."
 
 # import developer certificates

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -42,11 +42,10 @@ echo "✅ Done installing Apple certificates."
 # ensure we're going to import the correct developer certificates into keychain
 echo "🏃 Running sanity check on our Developer certificates before importing …"
 echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
-echo "Using OpenSSL:" `openssl version`
-echo `which openssl`
-# openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
-# openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
-# echo "✅ Done running sanity check on our Developer certificates before importing."
+echo "Using OpenSSL:" `/usr/bin/openssl version`
+/usr/bin/openssl pkcs12 -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
+/usr/bin/openssl pkcs12 -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
+echo "✅ Done running sanity check on our Developer certificates before importing."
 
 # import developer certificates
 echo "🏃 Importing our Developer certificates …"

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -16,6 +16,8 @@ echo -n "$INSTALLER_CERT_BASE64" | base64 --decode --output $INSTALLER_CERT_PATH
 echo "✅ Done retrieving our Developer certificates from GH secrets."
 
 echo "🏃 Displaying information on our Developer certificates …"
+echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
+echo "Using OpenSSL:" `openssl version`
 openssl pkcs12 -legacy -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
 openssl pkcs12 -legacy -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
 echo "✅ Done displaying information on our Developer certificates."
@@ -47,9 +49,9 @@ echo "✅ Done installing Apple certificates."
 # ensure we're going to import the correct developer certificates into keychain
 echo "🏃 Running sanity check on our Developer certificates before importing …"
 echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
-echo "Using OpenSSL:" `/usr/bin/openssl version`
-/usr/bin/openssl pkcs12 -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
-/usr/bin/openssl pkcs12 -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
+echo "Using OpenSSL:" `openssl version`
+openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
+openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
 echo "✅ Done running sanity check on our Developer certificates before importing."
 
 # import developer certificates

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -39,10 +39,11 @@ security add-certificates -k $KEYCHAIN_PATH ./AppleWWDRCA.cer
 echo "✅ Done installing Apple certificates."
 
 # ensure we're going to import the correct developer certificates into keychain
-# echo "🏃 Running sanity check on our Developer certificates before importing …"
-# openssl pkcs12 -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
-# openssl pkcs12 -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
-# echo "✅ Done running sanity check on our Developer certificates before importing."
+echo "🏃 Running sanity check on our Developer certificates before importing …"
+echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
+openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
+openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
+echo "✅ Done running sanity check on our Developer certificates before importing."
 
 # import developer certificates
 echo "🏃 Importing our Developer certificates …"

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -16,8 +16,8 @@ echo -n "$INSTALLER_CERT_BASE64" | base64 --decode --output $INSTALLER_CERT_PATH
 echo "✅ Done retrieving our Developer certificates from GH secrets."
 
 echo "🏃 Displaying information on our Developer certificates …"
-/usr/bin/openssl pkcs12 -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
-/usr/bin/openssl pkcs12 -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
+openssl -legacy pkcs12 -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
+openssl -legacy pkcs12 -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
 echo "✅ Done displaying information on our Developer certificates."
 
 # create temporary keychain

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefail
+set -xeo pipefail
 
 # Based on https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
 # create variables

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -xeo pipefail
+set -eo pipefail
 
 # Based on https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
 # create variables
@@ -42,8 +42,8 @@ echo "✅ Done installing Apple certificates."
 echo "🏃 Running sanity check on our Developer certificates before importing …"
 echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
 echo "Using OpenSSL:" `openssl version`
-openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
-openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
+openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH  #| grep friendlyName
+openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH  #| grep friendlyName
 echo "✅ Done running sanity check on our Developer certificates before importing."
 
 # import developer certificates

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -39,10 +39,11 @@ sudo security add-trusted-cert -d -r trustRoot -k $KEYCHAIN_PATH ./AppleComputer
 security add-certificates -k $KEYCHAIN_PATH ./AppleWWDRCA.cer
 echo "✅ Done installing Apple certificates."
 
-# # ensure we're going to import the correct developer certificates into keychain
-# echo "🏃 Running sanity check on our Developer certificates before importing …"
-# echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
-# echo "Using OpenSSL:" `openssl version`
+# ensure we're going to import the correct developer certificates into keychain
+echo "🏃 Running sanity check on our Developer certificates before importing …"
+echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
+echo "Using OpenSSL:" `openssl version`
+echo `which openssl`
 # openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
 # openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
 # echo "✅ Done running sanity check on our Developer certificates before importing."

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -39,10 +39,10 @@ security add-certificates -k $KEYCHAIN_PATH ./AppleWWDRCA.cer
 echo "✅ Done installing Apple certificates."
 
 # ensure we're going to import the correct developer certificates into keychain
-echo "🏃 Running sanity check on our Developer certificates before importing …"
-openssl pkcs12 -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
-openssl pkcs12 -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
-echo "✅ Done running sanity check on our Developer certificates before importing."
+# echo "🏃 Running sanity check on our Developer certificates before importing …"
+# openssl pkcs12 -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
+# openssl pkcs12 -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
+# echo "✅ Done running sanity check on our Developer certificates before importing."
 
 # import developer certificates
 echo "🏃 Importing our Developer certificates …"

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -16,8 +16,8 @@ echo -n "$INSTALLER_CERT_BASE64" | base64 --decode --output $INSTALLER_CERT_PATH
 echo "✅ Done retrieving our Developer certificates from GH secrets."
 
 echo "🏃 Displaying information on our Developer certificates …"
-/usr/bin/openssl pkcs12 -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
-/usr/bin/openssl pkcs12 -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
+openssl pkcs12 -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
+openssl pkcs12 -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
 echo "✅ Done displaying information on our Developer certificates."
 
 # create temporary keychain

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -13,42 +13,60 @@ echo -n "$APPLICATION_CERT_BASE64" | base64 --decode --output $APPLICATION_CERT_
 echo -n "$INSTALLER_CERT_BASE64" | base64 --decode --output $INSTALLER_CERT_PATH
 
 # create temporary keychain
+echo "🏃 Creating temporary keychains …"
 security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
 security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+echo "✅ Done creating temporary keychains."
 
 # download Apple certificates
+echo "🏃 Downloading Apple certificates …"
 curl https://www.apple.com/appleca/AppleIncRootCertificate.cer -L --output AppleIncRootCertificate.cer
 curl https://www.apple.com/certificateauthority/AppleComputerRootCertificate.cer -L --output AppleComputerRootCertificate.cer
 curl http://developer.apple.com/certificationauthority/AppleWWDRCA.cer -L --output AppleWWDRCA.cer
+echo "✅ Done downloading Apple certificates."
 
 # install Apple certificates
 # the following line is required for macOS 11+, see
 # https://developer.apple.com/forums/thread/671582?answerId=693632022#693632022
+echo "🏃 Installing Apple certificates …"
 sudo security authorizationdb write com.apple.trust-settings.admin allow
 sudo security add-trusted-cert -d -r trustRoot -k $KEYCHAIN_PATH ./AppleIncRootCertificate.cer
 sudo security add-trusted-cert -d -r trustRoot -k $KEYCHAIN_PATH ./AppleComputerRootCertificate.cer
 security add-certificates -k $KEYCHAIN_PATH ./AppleWWDRCA.cer
+echo "✅ Done installing Apple certificates."
 
 # ensure we're going to import the correct developer certificates into keychain
+echo "🏃 Running sanity check on our Developer certificates before importing …"
 openssl pkcs12 -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
 openssl pkcs12 -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
+echo "✅ Done running sanity check on our Developer certificates before importing."
 
 # import developer certificates
+echo "🏃 Importing our Developer certificates …"
 security import $APPLICATION_CERT_PATH -P "$APPLICATION_CERT_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
 security import $INSTALLER_CERT_PATH -P "$INSTALLER_CERT_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+echo "✅ Done importing our Developer certificates."
 
 # ensure the imported certificates are valid
+echo "🏃 Ensuring the imported cerificates are valid …"
 security find-identity -v $KEYCHAIN_PATH
+echo "✅ Done ensuring the imported cerificates are valid."
 
 # Avoid a password prompt; what this actually does is not properly
 # documented; see https://github.com/fastlane/fastlane/issues/13564#issue-372273249
 # and https://stackoverflow.com/a/40039594
 # FIXME: Really needed?
+echo "🏃 Disabling keychain password prompt …"
 security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+echo "✅ Done disabling keychain password prompt."
 
 # Make the keychain the default
+echo "🏃 Setting default keychain …"
 security default-keychain -s $KEYCHAIN_PATH
+echo "✅ Done setting default keychain."
 
 # List available signing identities (for debugging purposes)
+echo "🏃 Listing available signing identities …"
 security find-identity
+echo "✅ Done listing available signing identities."

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -39,13 +39,13 @@ sudo security add-trusted-cert -d -r trustRoot -k $KEYCHAIN_PATH ./AppleComputer
 security add-certificates -k $KEYCHAIN_PATH ./AppleWWDRCA.cer
 echo "✅ Done installing Apple certificates."
 
-# ensure we're going to import the correct developer certificates into keychain
-echo "🏃 Running sanity check on our Developer certificates before importing …"
-echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
-echo "Using OpenSSL:" `openssl version`
-openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
-openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
-echo "✅ Done running sanity check on our Developer certificates before importing."
+# # ensure we're going to import the correct developer certificates into keychain
+# echo "🏃 Running sanity check on our Developer certificates before importing …"
+# echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
+# echo "Using OpenSSL:" `openssl version`
+# openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
+# openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
+# echo "✅ Done running sanity check on our Developer certificates before importing."
 
 # import developer certificates
 echo "🏃 Importing our Developer certificates …"

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -15,6 +15,11 @@ echo -n "$APPLICATION_CERT_BASE64" | base64 --decode --output $APPLICATION_CERT_
 echo -n "$INSTALLER_CERT_BASE64" | base64 --decode --output $INSTALLER_CERT_PATH
 echo "✅ Done retrieving our Developer certificates from GH secrets."
 
+echo "🏃 Displaying information on our Developer certificates …"
+/usr/bin/openssl pkcs12 -info -noout -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH
+/usr/bin/openssl pkcs12 -info -noout -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH
+echo "✅ Done displaying information on our Developer certificates."
+
 # create temporary keychain
 echo "🏃 Creating temporary keychain …"
 security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH

--- a/tools/macos_install_certificates.sh
+++ b/tools/macos_install_certificates.sh
@@ -43,8 +43,8 @@ echo "✅ Done installing Apple certificates."
 echo "🏃 Running sanity check on our Developer certificates before importing …"
 echo "⛔️ WARNING: USING OPENSSL LEGACY MODE. PLEASE FIX THIS."
 echo "Using OpenSSL:" `openssl version`
-openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH #| grep friendlyName
-openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH #| grep friendlyName
+openssl pkcs12 -legacy -nokeys -passin pass:"$APPLICATION_CERT_PASSWORD" -in $APPLICATION_CERT_PATH | grep friendlyName
+openssl pkcs12 -legacy -nokeys -passin pass:"$INSTALLER_CERT_PASSWORD" -in $INSTALLER_CERT_PATH | grep friendlyName
 echo "✅ Done running sanity check on our Developer certificates before importing."
 
 # import developer certificates


### PR DESCRIPTION
Closes #232


cc @larsoner 

I would almost bet it's the `openssl` commands that are the issue; they're optional and we could just drop them for now to push out a release quickly. But let's wait and see