### PR TITLE
MAINT: Bump to 1.6.1

### DIFF
--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -72,7 +72,7 @@ specs:
   # - mne-installer-menus =1.4dev0=*_20230503
   # - mne-bids =0.11dev0=*_20221007
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
-  - mne =1.6.0=*_0
+  - mne =1.6.1=*_0
   - mne-installer-menus =1.6.0=*_0
   # For testing purposes with build_local.sh, you can comment out all deps
   # below for speed, and change mne to mne-base above
@@ -150,7 +150,7 @@ specs:
   - git =2.43.0  # [win]
   - make =4.3  # [win]
   - ipywidgets =8.1.1
-  - pyvista =0.42.3
+  - pyvista =0.43.2
   - pyvistaqt =0.11.0
   - trame =3.5.1
   - trame-vtk =2.7.0

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -64,7 +64,7 @@ specs:
   - pip =23.3.2
   - conda =23.10.0
   - mamba =1.5.3
-  - fmt =10.2.1
+  - fmt =10.1.1
   - conda-libmamba-solver =23.11.1
   # MNE ecosystem
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
@@ -73,7 +73,7 @@ specs:
   # - mne-bids =0.11dev0=*_20221007
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
   - mne =1.6.1=*_0
-  - mne-installer-menus =1.6.0=*_0
+  - mne-installer-menus =1.6.1=*_0
   # For testing purposes with build_local.sh, you can comment out all deps
   # below for speed, and change mne to mne-base above
   - mne-bids =0.14

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -64,7 +64,7 @@ specs:
   - pip =23.3.2
   - conda =23.10.0
   - mamba =1.5.3
-  - fmt =10.1.1
+  - fmt =10.2.1
   - conda-libmamba-solver =23.11.1
   # MNE ecosystem
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
@@ -87,7 +87,7 @@ specs:
   - mne-rsa =0.9
   - mne-ari =0.1.2
   - mne-kit-gui =1.2.0
-  - mne-icalabel =0.5.1
+  - mne-icalabel =0.6.0
   - mne-gui-addons =0.1.0
   - mne-lsl =1.1.1
   - traitsui =8.0.0

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -28,11 +28,9 @@ allowed_outdated: set[str] = {
     "conda",
     "conda-libmamba-solver",
     "mamba",  # conda/mamba conflict with tensorflow and VTK
-    "fmt",  # 10.2.0 broken metadata/Windows DLL problem
     "tensorflow",  # 2.13.1 conflicts with VTK
     "graphviz",  # conflicts with VTK
     "pydata-sphinx-theme",  # haven't updated to latest version in our conf.py
-    "pyvista",  # incompatible with 1.6.0
     "openblas",  # Needs https://github.com/conda-forge/blas-feedstock/pull/113
 }
 packages: list[Package] = []

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -28,6 +28,7 @@ allowed_outdated: set[str] = {
     "conda",
     "conda-libmamba-solver",
     "mamba",  # conda/mamba conflict with tensorflow and VTK
+    "fmt",  # 10.2.0 broken metadata/Windows DLL problem
     "tensorflow",  # 2.13.1 conflicts with VTK
     "graphviz",  # conflicts with VTK
     "pydata-sphinx-theme",  # haven't updated to latest version in our conf.py


### PR DESCRIPTION
Needs https://github.com/conda-forge/mne-feedstock/pull/128 and CDN update but will mark for merge-when-green and restart CIs until it's in, then cut a 1.6.1 release here