### PR TITLE
ENH: Include pyobjc for setting name

### DIFF
--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -100,10 +100,10 @@ specs:
   - openblas =0.3.26
   - libblas =3.9.0=*openblas
   - jupyter =1.0.0
-  - jupyterlab =4.1.4
+  - jupyterlab =4.1.5
   - ipykernel =6.29.3
   - spyder-kernels =2.5.1
-  - spyder =5.5.1
+  - spyder =5.5.2
   - darkdetect =0.8.0
   - qdarkstyle =3.2.3
   - numba =0.59.0
@@ -152,10 +152,11 @@ specs:
   - ipywidgets =8.1.2
   - pyvista =0.43.4
   - pyvistaqt =0.11.0
-  - trame =3.5.2
+  - trame =3.5.3
   - trame-vtk =2.8.5
-  - trame-vuetify =2.4.2
+  - trame-vuetify =2.4.3
   - termcolor =2.4.0
+  - pyobjc-core =10.1  # [osx]
   # Development
   - setuptools_scm =8.0.4
   - pytest =7.4.4

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -59,3 +59,6 @@ import pyvistaqt
 import vtk
 
 check_min_version(pyvistaqt, "0.11.0")
+
+if platform.system() == "Darwin":
+    import Foundation  # pyobjc


### PR DESCRIPTION
Should maybe be upstreamed into `mne-python-feedstock`