### PR TITLE
MAINT: Update to v1.7.1

### DIFF
--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -144,7 +144,7 @@ specs:
   - ipympl =0.9.4
   - seaborn =0.13.2
   - plotly =5.22.0
-  - vtk =9.3.0
+  - vtk =9.2.6
   - git =2.45.2  # [win]
   - make =4.3  # [win]
   - ipywidgets =8.1.3

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -75,8 +75,8 @@ specs:
   # below for speed, and change mne to mne-base above
   - mne-bids =0.15.0
   - mne-bids-pipeline =1.8.0
-  - mne-qt-browser =0.6.2
-  - mne-connectivity =0.6.0
+  - mne-qt-browser =0.6.3
+  - mne-connectivity =0.7.0
   # - mne-faster =1.1.0  # Not 1.7.0-compatible
   - mne-nirs =0.6.0
   - mne-features =0.3
@@ -100,21 +100,21 @@ specs:
   - jupyter =1.0.0
   - jupyterlab =4.2.2
   - ipykernel =6.29.4
-  - spyder-kernels =2.5.1
-  - spyder =5.5.4
+  - spyder-kernels =2.5.2
+  - spyder =5.5.5
   - darkdetect =0.8.0
   - qdarkstyle =3.2.3
   - numba =0.59.1
   - cython =3.0.10
   # I/O
   - pyxdf =1.16.6
-  - openpyxl =3.1.2
+  - openpyxl =3.1.4
   - xlrd =2.0.1
   - snirf =0.8.0
   # Statistics
   - pingouin =0.5.4
   # MRI
-  - fsleyes =1.12.2
+  - fsleyes =1.12.3
   - dcm2niix =1.0.20240202
   - dipy =1.9.0
   # Time-frequency analysis
@@ -135,7 +135,7 @@ specs:
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.9
   # GitHub client, https://cli.github.com
-  - gh =2.50.0
+  - gh =2.51.0
   # NeuroSpin needs the following
   - questionary =2.0.1
   - pqdm =0.2.0
@@ -144,15 +144,15 @@ specs:
   - ipympl =0.9.4
   - seaborn =0.13.2
   - plotly =5.22.0
-  - vtk =9.2.6
-  - git =2.45.1  # [win]
+  - vtk =9.3.0
+  - git =2.45.2  # [win]
   - make =4.3  # [win]
   - ipywidgets =8.1.3
   - pyvista =0.43.9
   - pyvistaqt =0.11.0
   - trame =3.6.2
   - trame-vtk =2.8.9
-  - trame-vuetify =2.5.0
+  - trame-vuetify =2.6.0
   - termcolor =2.4.0
   - pyobjc-core =10.2  # [osx]
   - defusedxml =0.7.1

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -69,8 +69,8 @@ specs:
   # - mne-installer-menus =1.4dev0=*_20230503
   # - mne-bids =0.11dev0=*_20221007
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
-  - mne =1.7.1=*_1
-  - mne-installer-menus =1.7.1=*_1
+  - mne =1.7.1=*_0
+  - mne-installer-menus =1.7.1=*_0
   # For testing purposes with build_local.sh, you can comment out all deps
   # below for speed, and change mne to mne-base above
   - mne-bids =0.15.0

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -163,7 +163,7 @@ specs:
   - pytest-qt =4.4.0
   - pytest-timeout =2.3.1
   - pre-commit =3.7.1
-  - ruff =0.4.8
+  - ruff =0.4.9
   - check-manifest =0.49.0
   - codespell =2.3.0
   - nitime =0.10.2

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -69,8 +69,8 @@ specs:
   # - mne-installer-menus =1.4dev0=*_20230503
   # - mne-bids =0.11dev0=*_20221007
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
-  - mne =1.7.0=*_1
-  - mne-installer-menus =1.7.0=*_1
+  - mne =1.7.1=*_1
+  - mne-installer-menus =1.7.1=*_1
   # For testing purposes with build_local.sh, you can comment out all deps
   # below for speed, and change mne to mne-base above
   - mne-bids =0.15.0

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -44,6 +44,7 @@ allowed_outdated: set[str] = {
     "graphviz",  # conflicts with VTK 9.2.6 via libexpat
     "mne-rsa",  # 0.91 appeared on conda-forge and was yanked
     "pyobjc-core",  # 10.3 conflicted with pyobjc-framework-cocoa on 2024/05/28
+    "vtk",  # 9.3.0 is out but mayavi (at least) hasn't been migrated
 }
 packages: list[Package] = []
 


### PR DESCRIPTION
Empty commit to start until https://github.com/mne-tools/mne-python/pull/12666 lands, PyPI is pushed, conda-forge is updated. Then I can update to v1.7.1 here and mark for merge-when-green. In the meantime the `autofix.ci` can push an update for outdated deps and we can make sure that's green at least.