### PR TITLE
BUG: Fix bug with artifact download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,7 +245,7 @@ jobs:
       # These names should correspond to MNE_INSTALLER_ARTIFACT_ID in tools/extract_version.sh
       - uses: actions/download-artifact@v4
         with:
-          name: MNE-Python-*
+          pattern: MNE-Python-*
           merge-multiple: true
       - run: ls -al ./
       - uses: ncipollo/release-action@v1


### PR DESCRIPTION
https://github.com/mne-tools/mne-installers/actions/runs/9764227628/job/26953942126 actually failed so I'll change the merge reqs to have the `Release` step required and sanity check this one by eyeballing the `ls -al ./` step