### PR TITLE
ENH: Track outdated allows in recipe

### DIFF
--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -192,7 +192,7 @@ specs:
   - hatchling =1.25.0
   - hatch-vcs =0.4.0
   - mypy =1.11.1
-  - towncrier =23.11.0
+  - towncrier =23.11.0  # allow_outdated, 24.7.1 doesn't work with sphinxcontrib-towncrier
   - vulture =2.11
   # Doc building
   - numpydoc =1.8.0
@@ -200,7 +200,7 @@ specs:
   - graphviz =12.0.0
   - python-graphviz =0.20.3
   - selenium =4.23.1
-  - sphinx =7.4.7
+  - sphinx =7.4.7  # allow_outdated, sphinx-design not 8.0 compatible
   - sphinx-design =0.6.1
   - sphinx-gallery =0.17.1
   - sphinxcontrib-bibtex =2.6.2

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -182,7 +182,7 @@ specs:
   - pytest-timeout =2.3.1
   - pre-commit =3.8.0
   - ruff =0.5.7
-  - uv =0.2.35
+  - uv =0.2.36
   - check-manifest =0.49.0
   - codespell =2.3.0
   - py-spy =0.3.14
@@ -206,7 +206,7 @@ specs:
   - sphinxcontrib-bibtex =2.6.2
   - sphinx-copybutton =0.5.2
   - sphinxcontrib-youtube =1.4.1
-  - intersphinx-registry =0.2406.4
+  - intersphinx-registry =0.2408.13
   # OS-specific
   - git =2.46.0  # [win]
   - make =4.3  # [win]


### PR DESCRIPTION
I never liked having to modify `test_outdated.py` *and* `construct.yaml` when something is incompatible. This PR allows us just to update `construct.yaml` by marking *in that file* if something is out of date with an `allow_outdated` comment. So now changes and updates to dependencies can hopefully all occur in `construct.yaml` rather than being split across two files.