### PR TITLE
MAINT: Streamline import tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,6 +158,7 @@ jobs:
         with:
           qt: true
           pyvista: false
+          wm: false
       - run: ./tools/check_installation.sh
 
   test_linux:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,6 +190,7 @@ jobs:
         with:
           qt: true
           pyvista: false
+          wm: false
       - run: ./tools/check_installation.sh
 
   test_windows:
@@ -224,6 +225,7 @@ jobs:
         with:
           qt: true
           pyvista: false
+          wm: false
       - run: ./tools/check_installation.sh
         timeout-minutes: 5  # < 2 min even on Windows
 

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -110,11 +110,11 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2024.2.0
   # sleep staging
-  # - sleepecg =0.5.9=*_1  # TODO: Needs CDN update
+  - sleepecg =0.5.9=*_1
   # - yasa =0.6.5  # TODO: Needs antropy which needs stochastic which is pinned to NP<2 https://github.com/crflynn/stochastic/issues/79, https://github.com/raphaelvallat/antropy/issues/40
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10
-  - mnelab =0.9.2
+  - mnelab =1.0.0
   # other
   - pyriemann =0.7
   - pyprep =0.4.3=*_1

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -60,7 +60,7 @@ specs:
   - python =3.12.7  # allow_outdated, vtk
   - pip =25.0
   - wheel =0.45.1
-  - conda =25.1.0
+  - conda =25.1.1
   - mamba =2.0.5
   # MNE ecosystem
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
@@ -90,7 +90,7 @@ specs:
   - mne-kit-gui =1.3.0
   - autoreject =0.4.3
   - antio =0.5.0
-  # - wfdb =4.2.0  # TODO: 4.2.0 not on CF yet https://github.com/conda-forge/wfdb-feedstock/pull/29
+  - wfdb =4.2.0
   - meegkit =0.1.7
   - eeg_positions =2.1.2
   # MRI
@@ -101,7 +101,7 @@ specs:
   - pactools =0.3.1
   - tensorpac =0.6.5
   - emd =0.8.0
-  - neurodsp =2.2.0
+  # - neurodsp =2.2.0  # TODO: broken with latest SciPy
   # - bycycle =1.1.0  # TODO: broken with latest SciPy
   - fooof =1.0.0
   # Microstates
@@ -110,8 +110,8 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2024.2.0
   # sleep staging
-  # - sleepecg =0.5.8  # TODO: Not NumPy 2.0 compatible yet
-  # - yasa =0.6.5  # TODO: Needs sleepecg
+  - sleepecg =0.5.9
+  - yasa =0.6.5
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10
   - mnelab =0.9.2
@@ -120,6 +120,7 @@ specs:
   - pyprep =0.4.3=*_1
   - python-picard =0.8
   - pybv =0.7.6
+  - edfio =0.4.5
   - eeglabio =0.0.3
   - mffpy =0.10.0
   - openmeeg =2.5.15
@@ -170,7 +171,7 @@ specs:
   - ipympl =0.9.6
   - qtpy =2.4.2
   - seaborn =0.13.2
-  - plotly =5.24.1
+  - plotly =6.0.0
   - vtk =9.3.1=qt*
   - ipywidgets =8.1.5
   - pyvista =0.44.2
@@ -181,15 +182,15 @@ specs:
   - termcolor =2.5.0
   - defusedxml =0.7.1
   # Development
-  - gh =2.65.0
+  - gh =2.66.1
   - setuptools_scm =8.1.0
   - pytest =8.3.4
   - pytest-cov =6.0.0
   - pytest-qt =4.4.0
   - pytest-timeout =2.3.1
   - pre-commit =4.1.0
-  - ruff =0.9.3
-  - uv =0.5.25
+  - ruff =0.9.4
+  - uv =0.5.27
   - check-manifest =0.50
   - codespell =2.4.1
   - py-spy =0.4.0
@@ -204,7 +205,7 @@ specs:
   # Doc building
   - numpydoc =1.8.0
   - pydata-sphinx-theme =0.16.1
-  - graphviz =12.0.0
+  - graphviz =12.2.1
   - python-graphviz =0.20.3
   - selenium =4.28.1
   - sphinx =8.1.3

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -110,7 +110,7 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2024.2.0
   # sleep staging
-  - sleepecg =0.5.9=*_2
+  - sleepecg =0.5.9=*_1
   # - yasa =0.6.5  # TODO: Needs antropy which needs stochastic which is pinned to NP<2 https://github.com/crflynn/stochastic/issues/79, https://github.com/raphaelvallat/antropy/issues/40
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -110,8 +110,8 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2024.2.0
   # sleep staging
-  - sleepecg =0.5.9
-  # - yasa =0.6.5  # TODO: Needs stochastic which is errantly pinned to NP<2
+  # - sleepecg =0.5.9  # TODO: Needs TensorFlow which conflicts with a bunch of stuff
+  # - yasa =0.6.5  # TODO: Needs stochastic which is pinned to NP<2 https://github.com/crflynn/stochastic/issues/79
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10
   - mnelab =0.9.2
@@ -130,7 +130,6 @@ specs:
   # <<< END RELATED SOFTWARE LIST >>>
   # ^^^ this line is special and used by MNE-Python, do not change it!
 
-  - tensorflow =2.17.0  # needed by sleepecg
   - mayavi =4.8.2=pyside6_*
   - traitsui =8.0.0
   - pyface =8.0.0=*_1

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -110,7 +110,7 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2024.2.0
   # sleep staging
-  - sleepecg =0.5.9=*_1
+  # - sleepecg =0.5.9=*_1  # TODO: Needs CDN update
   # - yasa =0.6.5  # TODO: Needs antropy which needs stochastic which is pinned to NP<2 https://github.com/crflynn/stochastic/issues/79, https://github.com/raphaelvallat/antropy/issues/40
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -61,7 +61,7 @@ specs:
   - pip =25.0
   - wheel =0.45.1
   - conda =25.1.1
-  - mamba =2.0.5
+  - mamba =2.0.6
   # MNE ecosystem
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
   # - mne-base =1.4dev0=*_20230503

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -111,7 +111,7 @@ specs:
   - openneuro-py =2024.2.0
   # sleep staging
   - sleepecg =0.5.9
-  - yasa =0.6.5
+  # - yasa =0.6.5  # TODO: Needs stochastic which is errantly pinned to NP<2
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10
   - mnelab =0.9.2

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -110,8 +110,8 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2024.2.0
   # sleep staging
-  - sleepecg =0.5.9
-  - yasa =0.6.5
+  # - sleepecg =0.5.9  # TODO: TensorFlow conflicts
+  # - yasa =0.6.5  # TODO: Requires sleepecg
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10
   - mnelab =0.9.2

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -110,7 +110,7 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2024.2.0
   # sleep staging
-  # - sleepecg =0.5.9  # TODO: Needs TensorFlow which conflicts with a bunch of stuff
+  - sleepecg =0.5.9=*_1
   # - yasa =0.6.5  # TODO: Needs antropy which needs stochastic which is pinned to NP<2 https://github.com/crflynn/stochastic/issues/79, https://github.com/raphaelvallat/antropy/issues/40
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -111,7 +111,7 @@ specs:
   - openneuro-py =2024.2.0
   # sleep staging
   - sleepecg =0.5.9=*_2
-  # - yasa =0.6.5  # TODO: Needs antropy which needs stochastic which is pinned to NP<2 https://github.com/crflynn/stochastic/issues/79, https://github.com/raphaelvallat/antropy/issues/40
+  - yasa =0.6.5
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10
   - mnelab =1.0.0
@@ -130,6 +130,7 @@ specs:
   # <<< END RELATED SOFTWARE LIST >>>
   # ^^^ this line is special and used by MNE-Python, do not change it!
 
+  - antropy =0.1.9
   - mayavi =4.8.2=pyside6_*
   - traitsui =8.0.0
   - pyface =8.0.0=*_1
@@ -146,7 +147,7 @@ specs:
   - spyder-kernels =3.0.2
   # TODO: Needs to not require pyqt
   # https://github.com/spyder-ide/spyder/issues/20201
-  # spyder =5.5.5
+  # spyder =6.1.0
   - darkdetect =0.8.0
   - qdarkstyle =3.2.3
   - numba =0.61.0

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -110,7 +110,7 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2024.2.0
   # sleep staging
-  - sleepecg =0.5.9=*_1
+  - sleepecg =0.5.9=*_2
   # - yasa =0.6.5  # TODO: Needs antropy which needs stochastic which is pinned to NP<2 https://github.com/crflynn/stochastic/issues/79, https://github.com/raphaelvallat/antropy/issues/40
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -111,7 +111,7 @@ specs:
   - openneuro-py =2024.2.0
   # sleep staging
   # - sleepecg =0.5.9  # TODO: Needs TensorFlow which conflicts with a bunch of stuff
-  # - yasa =0.6.5  # TODO: Needs stochastic which is pinned to NP<2 https://github.com/crflynn/stochastic/issues/79
+  # - yasa =0.6.5  # TODO: Needs antropy which needs stochastic which is pinned to NP<2 https://github.com/crflynn/stochastic/issues/79, https://github.com/raphaelvallat/antropy/issues/40
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10
   - mnelab =0.9.2

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -110,8 +110,8 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2024.2.0
   # sleep staging
-  # - sleepecg =0.5.9  # TODO: TensorFlow conflicts
-  # - yasa =0.6.5  # TODO: Requires sleepecg
+  - sleepecg =0.5.9
+  - yasa =0.6.5
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10
   - mnelab =0.9.2
@@ -130,6 +130,7 @@ specs:
   # <<< END RELATED SOFTWARE LIST >>>
   # ^^^ this line is special and used by MNE-Python, do not change it!
 
+  - tensorflow =2.17.0  # needed by sleepecg
   - mayavi =4.8.2=pyside6_*
   - traitsui =8.0.0
   - pyface =8.0.0=*_1
@@ -205,7 +206,7 @@ specs:
   # Doc building
   - numpydoc =1.8.0
   - pydata-sphinx-theme =0.16.1
-  - graphviz =12.2.1
+  - graphviz =12.0.0  # allow_outdated, conflicts with PySide6 6.7.3
   - python-graphviz =0.20.3
   - selenium =4.28.1
   - sphinx =8.1.3

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -4,7 +4,6 @@ import faulthandler
 faulthandler.enable()
 
 import os
-import sys
 from pathlib import Path
 
 import numpy as np
@@ -54,11 +53,13 @@ fig.close()
 assert "MNEQtBrowser" in repr(fig), repr(fig)
 
 # mne-kit-gui
-print("Running mne-kit-gui tests")
-from pyface.api import GUI  # noqa
-import mne_kit_gui  # noqa
+if os.getenv("SKIP_MNE_KIT_GUI_TESTS", "").lower() in ("1", "true"):
+    print("Skipping MNE-KIT-GUI tests")
+else:
+    print("Running MNE-KIT-GUI tests")
+    from pyface.api import GUI  # noqa
+    import mne_kit_gui  # noqa
 
-if sys.platform != "darwin":  # can be problematic on qt6 on macOS
     os.environ["_MNE_GUI_TESTING_MODE"] = "true"
     gui = GUI()
     gui.process_events()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -23,8 +23,10 @@ assert want in repr(fig.canvas), repr(fig.canvas)
 plt.close("all")
 
 # pyvistaqt
-print("Running pyvistaqt tests (except Windows)")
-if not sys.platform.startswith("win"):
+if os.getenv("SKIP_PYVISTAQT_TESTS", "").lower() in ("1", "true"):
+    print("Skipping PyVistaQt tests")
+else:
+    print("Running pyvistaqt tests")
     fname = this_path / "test.png"
     mne.viz.set_3d_backend("pyvista")
     fig = mne.viz.create_3d_figure((400, 400), scene=False, show=True)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -6,7 +6,7 @@ import platform
 
 
 parser = argparse.ArgumentParser(prog="test_imports")
-parser.add_argument("--ignore", nargs="*", help="Modules to ignore")
+parser.add_argument("--ignore", nargs="*", help="Modules to ignore", default=[])
 parsed = parser.parse_args()
 
 
@@ -63,8 +63,9 @@ bad_ver = {
     "mne-faster",  # https://github.com/wmvanvliet/mne-faster/pull/7
     "mne-ari",  # https://github.com/john-veillette/mne-ari/pull/7
 }
+ignore = list(parsed.ignore) + ["dcm2niix"]
 for mod in tqdm(mods, desc="Imports", unit="module"):
-    if mod in (parsed.ignore or []):
+    if mod in ignore:
         continue
     use_mod = mod
     if use_mod.startswith("python-"):  # python-neo

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -63,6 +63,7 @@ bad_ver = {
     "mne-faster",  # https://github.com/wmvanvliet/mne-faster/pull/7
     "mne-ari",  # https://github.com/john-veillette/mne-ari/pull/7
     "pactools",  # https://github.com/pactools/pactools/pull/37
+    "Foundation",  # pyobjc
 }
 ignore = list(parsed.ignore) + ["dcm2niix"]
 for mod in tqdm(mods, desc="Imports", unit="module"):

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,78 +1,81 @@
+import argparse
+import importlib
+from tqdm import tqdm
+from pathlib import Path
 import platform
 
 
-def check_min_version(package, min_version):
+parser = argparse.ArgumentParser(prog="test_imports")
+parser.add_argument("--ignore", nargs="*", help="Modules to ignore")
+parsed = parser.parse_args()
+
+
+def _import(mod):
+    try:
+        return importlib.import_module(mod.replace("-", "_"))
+    except Exception:
+        raise ImportError(f"Could not import {repr(mod)}")
+
+
+def check_version_eq(package, ver):
     """Check a minimum version."""
     from packaging.version import parse
 
-    assert parse(package.__version__) >= parse(min_version), (
-        f"{package}: got {package.__version__} wanted {min_version}"
+    if isinstance(package, str):
+        package = _import(package)
+
+    try:
+        package_ver = parse(package.__version__)
+    except Exception:
+        raise ImportError(
+            f"Could not parse version for {package}: {repr(package.__version__)}"
+        )
+    assert package_ver >= parse(ver), (
+        f"{package}: got {package.__version__} wanted {ver}"
     )
 
 
-import mne
+# All related software
+lines = (
+    (Path(__file__).parents[1] / "recipes" / "mne-python" / "construct.yaml")
+    .read_text("utf-8")
+    .splitlines()
+)
+lines = [line.strip() for line in lines]
+all_lines = lines
+sidx = lines.index("# <<< BEGIN RELATED SOFTWARE LIST >>>")
+eidx = lines.index("# <<< END RELATED SOFTWARE LIST >>>")
+lines = [line for line in lines[sidx : eidx + 1] if not line.startswith("#")]
+assert lines
+mods = [line[2:].split("#")[0].split(">")[0].split("=")[0].strip() for line in lines]
 
-check_min_version(mne, "1.4")
-import mne_bids
-import mne_bids_pipeline
-
-check_min_version(mne_bids_pipeline, "1.2")
-import mne_connectivity
-
-import mne_faster
-import mne_nirs
-import mne_qt_browser
-
-check_min_version(mne_qt_browser, "0.5.0")
-import mne_features
-import mne_rsa
-import mne_microstates
-import mne_ari
-import mne_kit_gui
-import mne_lsl
-import mne_icalabel
-import autoreject
-
-# import wfdb  # TODO
-import meegkit
-import eeg_positions
-import pyriemann
-import pyprep
-import pycrostates
-import darkdetect
-import qdarkstyle
-import numba
-import openpyxl
-import xlrd
-import pingouin
-import pactools
-import tensorpac
-import emd
-import neurodsp
-
-# import bycycle  # TODO
-import fooof
-import openneuro
-
-# import sleepecg  # TODO
-# import yasa  # TODO
-import neo
-import neurokit2
-import questionary
-import matplotlib.pyplot
-import seaborn
-import plotly
-import pqdm
-import pyvistaqt
-import vtk
-import PySide6.QtCore
-
-import matplotlib.pyplot as plt
-
-backend = plt.get_backend()
-assert backend.lower() == "qtagg", backend
-
-check_min_version(pyvistaqt, "0.11.0")
-
+# Plus some custom ones
+mods += """
+darkdetect qdarkstyle numba openpyxl xlrd pingouin questionary
+seaborn plotly pqdm pyvistaqt vtk PySide6.QtCore matplotlib.pyplot
+""".strip().split()
 if platform.system() == "Darwin":
-    import Foundation  # pyobjc
+    mods += ["Foundation"]  # pyobjc
+
+# Now do the importing and version checking
+bad_ver = {
+    "mne-faster",  # https://github.com/wmvanvliet/mne-faster/pull/7
+    "mne-ari",  # https://github.com/john-veillette/mne-ari/pull/7
+}
+for mod in tqdm(mods, desc="Imports", unit="module"):
+    if mod in parsed.ignore:
+        continue
+    use_mod = mod
+    if use_mod.startswith("python-"):  # python-neo
+        use_mod = use_mod[7:]
+    if use_mod.endswith("-py"):  # openneuro-py
+        use_mod = use_mod[:-3]
+    py_mod = _import(use_mod)
+    if "." not in mod:  # don't check PySide6.QtCore etc.
+        ver_lines = [line for line in all_lines if line.startswith(f"- {mod} =")]
+        assert len(ver_lines) == 1, f"{mod}: {ver_lines}"
+        if mod not in bad_ver:
+            check_version_eq(py_mod, ver_lines[0].split("=")[1])
+    if mod == "matplotlib.pyplot":
+        backend = py_mod.get_backend()
+        assert backend.lower() == "qtagg", backend

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -63,16 +63,14 @@ bad_ver = {
     "mne-faster",  # https://github.com/wmvanvliet/mne-faster/pull/7
     "mne-ari",  # https://github.com/john-veillette/mne-ari/pull/7
     "pactools",  # https://github.com/pactools/pactools/pull/37
-    "matplotlib.pyplot",
-    "PySide6.QtCore",
 }
-mod_map = {
+mod_map = {  # for import test, need map from conda-forge line/name to importable name
     "python-neo": "neo",
     "python-picard": "picard",
     "openneuro-py": "openneuro",
     "pyobjc": "Foundation",
 }
-ver_map = {
+ver_map = {  # for __version__, need map from importable name to conda-forge line/name
     "matplotlib": "matplotlib-base",
 }
 ignore = list(parsed.ignore) + ["dcm2niix"]
@@ -80,7 +78,7 @@ for mod in tqdm(mods, desc="Imports", unit="module"):
     if mod in ignore:
         continue
     py_mod = _import(mod_map.get(mod, mod))
-    if mod not in bad_ver:
+    if mod not in bad_ver and "." not in mod:
         ver_lines = [
             line
             for line in all_lines

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -64,7 +64,7 @@ bad_ver = {
     "mne-ari",  # https://github.com/john-veillette/mne-ari/pull/7
 }
 for mod in tqdm(mods, desc="Imports", unit="module"):
-    if mod in parsed.ignore:
+    if mod in (parsed.ignore or []):
         continue
     use_mod = mod
     if use_mod.startswith("python-"):  # python-neo

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -62,6 +62,7 @@ if platform.system() == "Darwin":
 bad_ver = {
     "mne-faster",  # https://github.com/wmvanvliet/mne-faster/pull/7
     "mne-ari",  # https://github.com/john-veillette/mne-ari/pull/7
+    "pactools",  # https://github.com/pactools/pactools/pull/37
 }
 ignore = list(parsed.ignore) + ["dcm2niix"]
 for mod in tqdm(mods, desc="Imports", unit="module"):

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -47,6 +47,7 @@ sidx = lines.index("# <<< BEGIN RELATED SOFTWARE LIST >>>")
 eidx = lines.index("# <<< END RELATED SOFTWARE LIST >>>")
 lines = [line for line in lines[sidx : eidx + 1] if not line.startswith("#")]
 assert lines
+# NB: next line assumes that there are no "less-than" pins
 mods = [line[2:].split("#")[0].split(">")[0].split("=")[0].strip() for line in lines]
 
 # Plus some custom ones

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -63,12 +63,12 @@ bad_ver = {
     "mne-faster",  # https://github.com/wmvanvliet/mne-faster/pull/7
     "mne-ari",  # https://github.com/john-veillette/mne-ari/pull/7
     "pactools",  # https://github.com/pactools/pactools/pull/37
+    "Foundation",
 }
 mod_map = {  # for import test, need map from conda-forge line/name to importable name
     "python-neo": "neo",
     "python-picard": "picard",
     "openneuro-py": "openneuro",
-    "pyobjc": "Foundation",
 }
 ver_map = {  # for __version__, need map from importable name to conda-forge line/name
     "matplotlib": "matplotlib-base",

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -1,10 +1,16 @@
 # Create one nbclient and reuse it
+import os
 from mne.utils import Bunch
 import nbformat
 from jupyter_client import AsyncKernelManager
 from nbclient import NotebookClient
 from ipywidgets import Button  # noqa
-import ipyvtklink  # noqa
+
+if os.getenv("SKIP_NOTEBOOK_TESTS", "").lower() in ("1", "true"):
+    print("Skipping notebook tests")
+    exit(0)
+
+print("Running notebook tests")
 
 km = AsyncKernelManager(config=None)
 nb = nbformat.reads(

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -61,6 +61,11 @@ elif [[ "$MNE_MACHINE" == "Linux" ]]; then
     # Display their contents
     for f in mne-python*.desktop; do echo "📂 $f:"; cat "$f"; echo; done
     popd
+    if [[ `grep "24.04" /etc/lsb-release` ]]; then
+        export SKIP_PYVISTAQT_TESTS=1
+    fi
+else
+    export SKIP_PYVISTAQT_TESTS=1
 fi
 echo "::endgroup::"
 

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -61,6 +61,9 @@ elif [[ "$MNE_MACHINE" == "Linux" ]]; then
     # Display their contents
     for f in mne-python*.desktop; do echo "📂 $f:"; cat "$f"; echo; done
     popd
+    if [[ `grep "24.04" /etc/lsb-release` ]]; then
+        export SKIP_PYVISTAQT_TESTS=1
+    fi
 else
     export SKIP_PYVISTAQT_TESTS=1
 fi

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -64,7 +64,7 @@ elif [[ "$MNE_MACHINE" == "Linux" ]]; then
     popd
     if [[ `grep "24.04" /etc/lsb-release` ]]; then
         export SKIP_PYVISTAQT_TESTS=1
-        export SKIP_MNE_KIT_GUI_TESTS=1
+        export SKIP_NOTEBOOK_TESTS=1
     fi
 else
     export SKIP_PYVISTAQT_TESTS=1

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -61,9 +61,6 @@ elif [[ "$MNE_MACHINE" == "Linux" ]]; then
     # Display their contents
     for f in mne-python*.desktop; do echo "📂 $f:"; cat "$f"; echo; done
     popd
-    if [[ `grep "24.04" /etc/lsb-release` ]]; then
-        export SKIP_PYVISTAQT_TESTS=1
-    fi
 else
     export SKIP_PYVISTAQT_TESTS=1
 fi

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -40,6 +40,7 @@ if [[ "$MNE_MACHINE" == "macOS" ]]; then
     test `ls -d ${APP_DIR}/*.app | wc -l` -eq 5 || exit 1
     echo "Checking that the custom icon was set on the MNE folder in ${APP_DIR}"
     test -f /Applications/MNE-Python/Icon$'\r' || exit 1
+    export SKIP_MNE_KIT_GUI_TESTS=1
 elif [[ "$MNE_MACHINE" == "Linux" ]]; then
     echo "Checking that menu shortcuts were created …"
     pushd ~/.local/share/applications
@@ -63,6 +64,7 @@ elif [[ "$MNE_MACHINE" == "Linux" ]]; then
     popd
     if [[ `grep "24.04" /etc/lsb-release` ]]; then
         export SKIP_PYVISTAQT_TESTS=1
+        export SKIP_MNE_KIT_GUI_TESTS=1
     fi
 else
     export SKIP_PYVISTAQT_TESTS=1


### PR DESCRIPTION
Rather than list a bunch of `import <mod>` lines, let's parse the YAML file and import systematically. Now imports everything in our related software list, plus a handful of custom imports of other stuff like `PySide6` and `vtk` that it seems like we wanted.