### PR TITLE
ENH: Use Python 3.13

### DIFF
--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -57,7 +57,7 @@ channels:
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: COMMENT OUT BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 specs:
   # Python
-  - python =3.13.1
+  - python =3.13.2
   - pip =25.0.1
   - wheel =0.45.1
   - conda =25.1.1
@@ -79,7 +79,7 @@ specs:
   - mne-bids-pipeline =1.9.0
   - mne-qt-browser =0.6.3
   - mne-connectivity =0.7.0=*_1
-  - mne-faster =1.2.1
+  - mne-faster =1.2.2
   - mne-nirs =0.7.1
   - mne-features =0.3
   - mne-rsa =0.9.1
@@ -117,7 +117,7 @@ specs:
   - neurokit2 =0.2.10
   - mnelab =1.0.0
   # other
-  - pyriemann =0.7
+  - pyriemann =0.8
   - pyprep =0.4.3=*_1
   - python-picard =0.8
   - pybv =0.7.6
@@ -138,9 +138,9 @@ specs:
   - imageio-ffmpeg =0.6.0
   - pandas =2.2.3
   - polars =1.22.0
-  - scipy =1.15.1
+  - scipy =1.15.2
   - numpy =2.1.3  # allow_outdated, each new version has to wait for numba
-  - openblas =0.3.28
+  - openblas =0.3.29
   - libblas =3.9.0=*openblas
   - jupyter =1.1.1
   - jupyterlab =4.3.5
@@ -184,7 +184,7 @@ specs:
   - termcolor =2.5.0
   - defusedxml =0.7.1
   # Development
-  - gh =2.66.1
+  - gh =2.67.0
   - setuptools_scm =8.1.0
   - pytest =8.3.4
   - pytest-cov =6.0.0
@@ -192,7 +192,7 @@ specs:
   - pytest-timeout =2.3.1
   - pre-commit =4.1.0
   - ruff =0.9.6
-  - uv =0.5.30
+  - uv =0.6.1
   - check-manifest =0.50
   - codespell =2.4.1
   - py-spy =0.4.0
@@ -210,15 +210,15 @@ specs:
   - graphviz =12.2.1
   - python-graphviz =0.20.3
   - selenium =4.28.1
-  - sphinx =8.1.3
+  - sphinx =8.2.0
   - sphinx-design =0.6.1
-  - sphinx-gallery =0.18.0
+  - sphinx-gallery =0.19.0
   - sphinxcontrib-bibtex =2.6.3
   - sphinx-copybutton =0.5.2
   - sphinxcontrib-youtube =1.4.1
   - intersphinx-registry =0.2501.23
   # OS-specific
-  - git =2.47.1  # [win]
+  - git =2.48.1  # [win]
   - make =4.4.1  # [win]
   - pyobjc-core =11.0  # [osx]
   - libffi =3.4.2  # [osx and arm64]  # allow_outdated

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -60,8 +60,9 @@ specs:
   - python =3.13.1
   - pip =25.0.1
   - wheel =0.45.1
-  - conda =25.1.1
-  - mamba =2.0.5
+  # TODO: RESTORE
+  # - conda =25.1.1
+  # - mamba =2.0.5
   # MNE ecosystem
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
   # - mne-base =1.4dev0=*_20230503

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -224,6 +224,8 @@ specs:
   - libffi =3.4.2  # [osx and arm64]  # allow_outdated
   - pyobjc-framework-Cocoa =11.0  # [osx]
   - pyobjc-framework-FSEvents =11.0  # [osx]
+  # https://github.com/conda-forge/libiconv-feedstock/issues/48
+  - libiconv =1.17  # [win]  # allow_outdated
 condarc:
   channels:
     - conda-forge

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -60,8 +60,7 @@ specs:
   - python =3.13.1
   - pip =25.0.1
   - wheel =0.45.1
-  # TODO: RESTORE
-  # - conda =25.1.1
+  - conda =25.1.1
   # - mamba =2.0.5
   # MNE ecosystem
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -61,7 +61,7 @@ specs:
   - pip =25.0.1
   - wheel =0.45.1
   - conda =25.1.1
-  # - mamba =2.0.5
+  - mamba =2.0.5
   # MNE ecosystem
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
   # - mne-base =1.4dev0=*_20230503
@@ -110,9 +110,8 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2024.2.0
   # sleep staging
-  # TODO: No 3.13-compatible release
-  # - sleepecg =0.5.9=*_2
-  # - yasa =0.6.5
+  - sleepecg =0.5.9=*_2
+  - yasa =0.6.5
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10
   - mnelab =1.0.0

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -140,7 +140,7 @@ specs:
   - polars =1.22.0
   - scipy =1.15.2
   - numpy =2.1.3  # allow_outdated, each new version has to wait for numba
-  - openblas =0.3.29
+  - openblas =0.3.28  # allow_outdated, NumPy etc. need to update
   - libblas =3.9.0=*openblas
   - jupyter =1.1.1
   - jupyterlab =4.3.5

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -57,7 +57,7 @@ channels:
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS STOP: COMMENT OUT BEFORE RELEASE! ⛔️ ⛔️ ⛔️
 specs:
   # Python
-  - python =3.12.7  # allow_outdated, vtk
+  - python =3.13.1
   - pip =25.0.1
   - wheel =0.45.1
   - conda =25.1.1
@@ -91,7 +91,7 @@ specs:
   - autoreject =0.4.3
   - antio =0.5.0
   - wfdb =4.2.0
-  - meegkit =0.1.7
+  - meegkit =0.1.9
   - eeg_positions =2.1.2
   # MRI
   - fsleyes =1.13.0
@@ -110,8 +110,9 @@ specs:
   # OpenNeuro.org data access
   - openneuro-py =2024.2.0
   # sleep staging
-  - sleepecg =0.5.9=*_2
-  - yasa =0.6.5
+  # TODO: No 3.13-compatible release
+  # - sleepecg =0.5.9=*_2
+  # - yasa =0.6.5
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.10
   - mnelab =1.0.0
@@ -167,10 +168,10 @@ specs:
   # https://github.com/conda-forge/matplotlib-feedstock/blob/main/recipe/meta.yaml
   - matplotlib-base =3.10.0
   - tornado =6.4.2
-  - pyside6 =6.7.3=*_1  # allow_outdated, vtk needs rebuild against 6.8.0 https://github.com/conda-forge/vtk-feedstock/pull/357
-  - qt6-main =6.7.3  # allow_outdated
+  - pyside6 =6.8.2
+  - qt6-main =6.8.2
   - ipympl =0.9.6
-  - qtpy =2.4.2
+  - qtpy =2.4.3
   - seaborn =0.13.2
   - plotly =6.0.0
   - vtk =9.3.1=qt*
@@ -206,7 +207,7 @@ specs:
   # Doc building
   - numpydoc =1.8.0
   - pydata-sphinx-theme =0.16.1
-  - graphviz =12.0.0  # allow_outdated, conflicts with PySide6 6.7.3
+  - graphviz =12.2.1
   - python-graphviz =0.20.3
   - selenium =4.28.1
   - sphinx =8.1.3

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -62,7 +62,7 @@ elif [[ "$MNE_MACHINE" == "Linux" ]]; then
     # Display their contents
     for f in mne-python*.desktop; do echo "📂 $f:"; cat "$f"; echo; done
     popd
-    if [[ `grep "24.04" /etc/lsb-release` ]]; then
+    if [[ `grep "24.04" /etc/lsb-release` ]] || [[ `grep "20.04" /etc/lsb-release` ]]; then
         export SKIP_PYVISTAQT_TESTS=1
         export SKIP_NOTEBOOK_TESTS=1
     fi


### PR DESCRIPTION
Have to remove `sleepecg` but I think everything else (vtk, mayavi, etc.) has been migrated. Might need CDN update though. I'll restart a few times and merge when green.