### PR TITLE
BUG: Fix bug with Linux max size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
           retention-days: 1
 
   build_macos:
+    if: false
     name: Build (${{ matrix.os }})
     needs: [build_local]
     strategy:
@@ -152,6 +153,7 @@ jobs:
           archive: false
 
   build_windows:
+    if: false
     name: Build (${{ matrix.os }})
     needs: [build_local]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
   build_local:
     name: Build local packages
     runs-on: ubuntu-latest
+    env:
+      CI_OS: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -el {0}
@@ -64,6 +66,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 50
     env:
+      CI_OS: ${{ matrix.os }}
       GITHUB_EVENT_NAME: ${{ github.event_name }}
     defaults:
       run:
@@ -124,6 +127,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     timeout-minutes: 50
+    env:
+      CI_OS: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -el {0}
@@ -160,6 +165,8 @@ jobs:
       matrix:
         os: [windows-latest]
     timeout-minutes: 50
+    env:
+      CI_OS: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -el {0}
@@ -197,6 +204,8 @@ jobs:
         os: [macos-15-intel, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 50
+    env:
+      CI_OS: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -el {0}
@@ -234,6 +243,8 @@ jobs:
         os: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 50
+    env:
+      CI_OS: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -el {0}
@@ -268,6 +279,8 @@ jobs:
         os: [windows-2022, windows-2025]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 80
+    env:
+      CI_OS: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,6 @@ jobs:
           retention-days: 1
 
   build_macos:
-    if: false
     name: Build (${{ matrix.os }})
     needs: [build_local]
     strategy:
@@ -153,7 +152,6 @@ jobs:
           archive: false
 
   build_windows:
-    if: false
     name: Build (${{ matrix.os }})
     needs: [build_local]
     runs-on: ${{ matrix.os }}

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -275,8 +275,10 @@ specs:
   - grayskull =3.1.0
   - conda-recipe-manager =0.10.1
   - conda-build =26.3.0
+  - constructor =3.15.3
   - conda-smithy =3.61.0
   - menuinst =2.4.2
+  - conda-standalone =26.1.1
   - cmake =4.3.1  # scipy
   - meson =1.11.1  # matplotlib, scipy
   - meson-python =0.19.0
@@ -284,6 +286,8 @@ specs:
   - click =8.2.1  # allow_outdated, needs conda-recipe-manager update
   - typer =0.24.1
   - libffi =3.5.2
+  - pythran =0.18.1
+  - gfortran =14.3.0
   # Doc building
   - numpydoc =1.10.0
   - pydata-sphinx-theme =0.17.1
@@ -299,22 +303,12 @@ specs:
   - sphinxcontrib-towncrier =0.5.0a0
   - intersphinx-registry =0.2603.16
   # OS-specific
-  # Windows installers must stay under 2GB due to nsis. r-base itself is fairly big,
-  # but (much) worse it requires gfortran, which in turn requires clang, which is big.
-  # pythran also requires gfortran.
-  - r-base =4.5.3  # [not win]
-  # https://github.com/conda-forge/rpy2-feedstock/issues/149
-  - rpy2 =3.6.6  # [not win]
-  - pythran =0.18.1  # [not win]  # pulls in clang, scipy
-  - gfortran =14.3.0  # [not win]  # allow_outdated, needs r-base update, scipy
-  # Linux installers need to be under 2GB to be attachable to GitHub releases
-  - constructor =3.15.3  # [not linux]
-  - conda-standalone =26.1.1  # [not linux]
   - git =2.53.0  # [win]
   - make =4.4.1  # [win]
   - pyobjc-core =12.1  # [osx]
   - pyobjc-framework-Cocoa =12.1  # [osx]
   - pyobjc-framework-FSEvents =12.1  # [osx]
+  #  r-base and rpy2 add too many dependencies, so we don't add them
 extra_envs:
   mne-kit-gui:
     channels:

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -275,12 +275,12 @@ specs:
   - grayskull =3.1.0
   - conda-recipe-manager =0.10.1
   - conda-build =26.3.0
-  - conda-smithy =3.60.0
+  - conda-smithy =3.61.0
   - constructor =3.15.3
   - menuinst =2.4.2
   - conda-standalone =26.1.1
   - cmake =4.3.1  # scipy
-  - meson =1.11.0  # matplotlib, scipy
+  - meson =1.11.1  # matplotlib, scipy
   - meson-python =0.19.0
   - pybind11 =3.0.3
   - click =8.2.1  # allow_outdated, needs conda-recipe-manager update
@@ -288,7 +288,7 @@ specs:
   - libffi =3.5.2
   # Doc building
   - numpydoc =1.10.0
-  - pydata-sphinx-theme =0.17.0
+  - pydata-sphinx-theme =0.17.1
   - graphviz =14.1.2
   - python-graphviz =0.21
   - selenium =4.43.0

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -281,13 +281,13 @@ specs:
   - conda-standalone =26.1.1
   - cmake =4.3.1  # scipy
   - meson =1.11.1  # matplotlib, scipy
+  - pythran =0.18.1  # scipy
+  - gfortran =15.2.0  # scipy
   - meson-python =0.19.0
   - pybind11 =3.0.3
   - click =8.2.1  # allow_outdated, needs conda-recipe-manager update
   - typer =0.24.1
   - libffi =3.5.2
-  - pythran =0.18.1
-  - gfortran =14.3.0
   # Doc building
   - numpydoc =1.10.0
   - pydata-sphinx-theme =0.17.1

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -275,8 +275,8 @@ specs:
   - grayskull =3.1.0
   - conda-recipe-manager =0.10.1
   - conda-build =26.3.0
-  - constructor =3.15.3
   - conda-smithy =3.61.0
+  - constructor =3.15.3
   - menuinst =2.4.2
   - conda-standalone =26.1.1
   - cmake =4.3.1  # scipy

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -276,9 +276,9 @@ specs:
   - conda-recipe-manager =0.10.1
   - conda-build =26.3.0
   - conda-smithy =3.61.0
-  - constructor =3.15.3
   - menuinst =2.4.2
-  - conda-standalone =26.1.1
+  - constructor =3.15.3  # [not linux]
+  - conda-standalone =26.1.1  # [not linux]
   - cmake =4.3.1  # scipy
   - meson =1.11.1  # matplotlib, scipy
   - meson-python =0.19.0

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -277,8 +277,6 @@ specs:
   - conda-build =26.3.0
   - conda-smithy =3.61.0
   - menuinst =2.4.2
-  - constructor =3.15.3  # [not linux]
-  - conda-standalone =26.1.1  # [not linux]
   - cmake =4.3.1  # scipy
   - meson =1.11.1  # matplotlib, scipy
   - meson-python =0.19.0
@@ -309,6 +307,9 @@ specs:
   - rpy2 =3.6.6  # [not win]
   - pythran =0.18.1  # [not win]  # pulls in clang, scipy
   - gfortran =14.3.0  # [not win]  # allow_outdated, needs r-base update, scipy
+  # Linux installers need to be under 2GB to be attachable to GitHub releases
+  - constructor =3.15.3  # [not linux]
+  - conda-standalone =26.1.1  # [not linux]
   - git =2.53.0  # [win]
   - make =4.4.1  # [win]
   - pyobjc-core =12.1  # [osx]

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -65,7 +65,7 @@ specs:
   # Python
   - python =3.13.9  # allow_outdated, 3.14+ will have to wait until all deps are ready
   - pip =26.0.1
-  - wheel =0.46.3
+  - wheel =0.47.0
   - conda =26.3.2
   - mamba =2.5.0
   - libmamba =2.5.0
@@ -258,7 +258,7 @@ specs:
   - pytest-qt =4.5.0
   - pytest-rerunfailures =16.1
   - pytest-timeout =2.4.0
-  - pre-commit =4.5.1
+  - pre-commit =4.6.0
   - ruff =0.15.11
   - uv =0.11.7
   - check-manifest =0.51
@@ -269,15 +269,15 @@ specs:
   - twine =6.2.0
   - hatchling =1.29.0
   - hatch-vcs =0.5.0
-  - mypy =1.20.1
+  - mypy =1.20.2
   - towncrier =25.8.0
   - vulture =2.16
   - grayskull =3.1.0
   - conda-recipe-manager =0.10.1
   - conda-build =26.3.0
-  - conda-smithy =3.61.0
+  - conda-smithy =3.61.1
   - menuinst =2.4.2
-  - cmake =4.3.1  # scipy
+  - cmake =4.3.2  # scipy
   - meson =1.11.1  # matplotlib, scipy
   - meson-python =0.19.0
   - pybind11 =3.0.3

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -276,13 +276,9 @@ specs:
   - conda-recipe-manager =0.10.1
   - conda-build =26.3.0
   - conda-smithy =3.61.0
-  - constructor =3.15.3
   - menuinst =2.4.2
-  - conda-standalone =26.1.1
   - cmake =4.3.1  # scipy
   - meson =1.11.1  # matplotlib, scipy
-  - pythran =0.18.1  # scipy
-  - gfortran =15.2.0  # scipy
   - meson-python =0.19.0
   - pybind11 =3.0.3
   - click =8.2.1  # allow_outdated, needs conda-recipe-manager update
@@ -303,12 +299,17 @@ specs:
   - sphinxcontrib-towncrier =0.5.0a0
   - intersphinx-registry =0.2603.16
   # OS-specific
+  - pythran =0.18.1  # [not win]  # pulls in clang, scipy
+  - gfortran =15.2.0  # [not win]  # scipy
   - git =2.53.0  # [win]
   - make =4.4.1  # [win]
   - pyobjc-core =12.1  # [osx]
   - pyobjc-framework-Cocoa =12.1  # [osx]
   - pyobjc-framework-FSEvents =12.1  # [osx]
-  #  r-base and rpy2 add too many dependencies, so we don't add them
+  # Size considerations:
+  # - r-base and rpy2 add too many dependencies, so we don't add them
+  # - constructor adds conda-standalone, which is ~50 MB
+
 extra_envs:
   mne-kit-gui:
     channels:

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -306,10 +306,9 @@ specs:
   - pyobjc-core =12.1  # [osx]
   - pyobjc-framework-Cocoa =12.1  # [osx]
   - pyobjc-framework-FSEvents =12.1  # [osx]
-  # Size considerations:
+  # Size considerations (must stay under 2GB for releases and Windows!):
   # - r-base and rpy2 add too many dependencies, so we don't add them
   # - constructor adds conda-standalone, which is ~50 MB
-
 extra_envs:
   mne-kit-gui:
     channels:

--- a/tests/test_json_versions.py
+++ b/tests/test_json_versions.py
@@ -2,11 +2,12 @@
 
 import fnmatch
 import json
-import os
 import pathlib
 import platform
 import sys
 import yaml
+
+from tqdm import tqdm
 
 dir_ = pathlib.Path(__file__).parent.parent
 
@@ -52,7 +53,7 @@ assert len(want_versions) > 2, len(want_versions)  # more than just the two abov
 
 # Extract versions from created environment
 fname = dir_ / f"MNE-Python-{installer_version}-{sys_name}{sys_ext}.env.json"
-assert fname.is_file(), (fname, os.listdir(os.getcwd()))
+assert fname.is_file(), f"{fname=}\n" + "\n".join(str(d) for d in dir_.iterdir())
 env_json = json.loads(fname.read_text(encoding="utf-8"))
 got_versions = dict()
 for package in env_json:
@@ -62,7 +63,7 @@ for package in env_json:
     }
 
 # check versions
-for package_name, want in want_versions.items():
+for package_name, want in tqdm(want_versions.items(), desc="Versions", unit="package"):
     got = got_versions[package_name]
     msg = f"{package_name}: got {repr(got)} != want {repr(want)}"
     assert got["version"] == want["version"], msg

--- a/tools/calculate_installer_hash.sh
+++ b/tools/calculate_installer_hash.sh
@@ -15,9 +15,9 @@ shasum -a 256 "$MNE_INSTALLER_NAME" > "$hash_fname"
 cat "$hash_fname"
 # need to raise an error if the installer is too big (it will fail to be part of any
 # release)
-#MAX_SIZE=2147483648
-#actual_size=$(stat -c%s "$MNE_INSTALLER_NAME")
-#if [ "$actual_size" -gt "$MAX_SIZE" ]; then
-#    echo "Error: Installer size ($actual_size bytes) exceeds the maximum allowed size ($MAX_SIZE bytes)."
-#    exit 1
-#fi
+MAX_SIZE=2147483648
+actual_size=$(stat -c%s "$MNE_INSTALLER_NAME")
+if [ "$actual_size" -gt "$MAX_SIZE" ]; then
+    echo "Error: Installer size ($actual_size bytes) exceeds the maximum allowed size ($MAX_SIZE bytes)."
+    # exit 1
+fi

--- a/tools/calculate_installer_hash.sh
+++ b/tools/calculate_installer_hash.sh
@@ -13,3 +13,11 @@ test "$installer_fname" == "$MNE_INSTALLER_NAME"
 hash_fname="${MNE_INSTALLER_NAME}.sha256.txt"
 shasum -a 256 "$MNE_INSTALLER_NAME" > "$hash_fname"
 cat "$hash_fname"
+# need to raise an error if the installer is too big (it will fail to be part of any
+# release)
+#MAX_SIZE=2147483648
+#actual_size=$(stat -c%s "$MNE_INSTALLER_NAME")
+#if [ "$actual_size" -gt "$MAX_SIZE" ]; then
+#    echo "Error: Installer size ($actual_size bytes) exceeds the maximum allowed size ($MAX_SIZE bytes)."
+#    exit 1
+#fi

--- a/tools/calculate_installer_hash.sh
+++ b/tools/calculate_installer_hash.sh
@@ -13,11 +13,3 @@ test "$installer_fname" == "$MNE_INSTALLER_NAME"
 hash_fname="${MNE_INSTALLER_NAME}.sha256.txt"
 shasum -a 256 "$MNE_INSTALLER_NAME" > "$hash_fname"
 cat "$hash_fname"
-# need to raise an error if the installer is too big (it will fail to be part of any
-# release)
-MAX_SIZE=2147483648
-actual_size=$(stat -c%s "$MNE_INSTALLER_NAME")
-if [ "$actual_size" -gt "$MAX_SIZE" ]; then
-    echo "Error: Installer size ($actual_size bytes) exceeds the maximum allowed size ($MAX_SIZE bytes)."
-    # exit 1
-fi

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -36,11 +36,12 @@ else
     SIZE_OPT="-c%s"
 fi
 ACTUAL_SIZE=$(stat $SIZE_OPT "$MNE_INSTALLER_NAME")
+DIFF_SIZE=$((MAX_SIZE - ACTUAL_SIZE))
 if [ "$ACTUAL_SIZE" -gt "$MAX_SIZE" ]; then
-    echo "Error: Installer size ($ACTUAL_SIZE bytes) exceeds the maximum allowed size ($MAX_SIZE bytes)."
+    echo "Error: Installer size ($ACTUAL_SIZE bytes) exceeds the maximum allowed size ($MAX_SIZE bytes) by $((-DIFF_SIZE)) bytes."
     exit 1
 else
-    echo "Installer size ($ACTUAL_SIZE bytes) is within the allowed limit ($MAX_SIZE bytes) by $((MAX_SIZE - ACTUAL_SIZE)) bytes."
+    echo "Installer size ($ACTUAL_SIZE bytes) is within the allowed limit ($MAX_SIZE bytes) by $DIFF_SIZE bytes."
 fi
 
 echo "::group::Platform specific tests for MNE_MACHINE=$MNE_MACHINE"

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -39,6 +39,8 @@ ACTUAL_SIZE=$(stat $SIZE_OPT "$MNE_INSTALLER_NAME")
 if [ "$ACTUAL_SIZE" -gt "$MAX_SIZE" ]; then
     echo "Error: Installer size ($ACTUAL_SIZE bytes) exceeds the maximum allowed size ($MAX_SIZE bytes)."
     exit 1
+else
+    echo "Installer size ($ACTUAL_SIZE bytes) is within the allowed limit ($MAX_SIZE bytes)."
 fi
 
 echo "::group::Platform specific tests for MNE_MACHINE=$MNE_MACHINE"

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -40,7 +40,7 @@ if [ "$ACTUAL_SIZE" -gt "$MAX_SIZE" ]; then
     echo "Error: Installer size ($ACTUAL_SIZE bytes) exceeds the maximum allowed size ($MAX_SIZE bytes)."
     exit 1
 else
-    echo "Installer size ($ACTUAL_SIZE bytes) is within the allowed limit ($MAX_SIZE bytes)."
+    echo "Installer size ($ACTUAL_SIZE bytes) is within the allowed limit ($MAX_SIZE bytes) by $((MAX_SIZE - ACTUAL_SIZE)) bytes."
 fi
 
 echo "::group::Platform specific tests for MNE_MACHINE=$MNE_MACHINE"

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -23,7 +23,7 @@ echo "::endgroup::"
 N=100
 echo "::group::package sizes (top $N)"
 # https://stackoverflow.com/a/67976448/2175965
-grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed 's/.*conda-meta\///g' | sed 's/"size": //g' | sed 's/,$//' > package_sizes.txt
+grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed -E 's/.*conda-meta\/(.+)\.json:\s+"size": (.+),/\1 \2/g' > package_sizes.txt
 head -n $N package_sizes.txt | column -t
 echo "::endgroup::"
 

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -20,15 +20,22 @@ echo "::group::pip list"
 pip list
 echo "::endgroup::"
 
-echo "::group::package sizes"
+N=100
+echo "::group::package sizes (top $N)"
 # https://stackoverflow.com/a/67976448/2175965
-grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed 's/.*conda-meta\///g' | column -t
+grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed 's/.*conda-meta\///g' | sed 's/"size": //g' | head -n $N | column -t
 echo "::endgroup::"
 
 # Now that we have the package sizes listed, raise an error if the installer is too big
 # (it will fail to attach to GH releases)
 MAX_SIZE=2147483648
-actual_size=$(stat -c%s "$MNE_INSTALLER_NAME")
+# I hate macOS sometimes
+if [[ "$MNE_MACHINE" == "macOS" ]]; then
+    SIZE_OPT="-f%s"
+else
+    SIZE_OPT="-c%s"
+fi
+actual_size=$(stat $SIZE_OPT "$MNE_INSTALLER_NAME")
 if [ "$actual_size" -gt "$MAX_SIZE" ]; then
     echo "Error: Installer size ($actual_size bytes) exceeds the maximum allowed size ($MAX_SIZE bytes)."
     exit 1

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -35,9 +35,9 @@ if [[ "$MNE_MACHINE" == "macOS" ]]; then
 else
     SIZE_OPT="-c%s"
 fi
-actual_size=$(stat $SIZE_OPT "$MNE_INSTALLER_NAME")
-if [ "$actual_size" -gt "$MAX_SIZE" ]; then
-    echo "Error: Installer size ($actual_size bytes) exceeds the maximum allowed size ($MAX_SIZE bytes)."
+ACTUAL_SIZE=$(stat $SIZE_OPT "$MNE_INSTALLER_NAME")
+if [ "$ACTUAL_SIZE" -gt "$MAX_SIZE" ]; then
+    echo "Error: Installer size ($ACTUAL_SIZE bytes) exceeds the maximum allowed size ($MAX_SIZE bytes)."
     exit 1
 fi
 

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -eo pipefail
-echo "Running tests for MNE_MACHINE=${MNE_MACHINE}"
+echo "Running tests for MNE_MACHINE=${MNE_MACHINE} on CI_OS=${CI_OS}"
 source "${MNE_ACTIVATE}"
 
 echo "::group::conda info"
@@ -127,9 +127,13 @@ python -c "import os; key = 'PYTHONNOUSERSITE'; x = os.getenv(key); assert x == 
 python -c "import os; key = 'MAMBA_NO_BANNER'; x = os.getenv(key); assert x == '1', f'{key}={repr(x)} != 1'"
 echo "::endgroup::"
 
-echo "::group::Testing mne sys_info"
-mne sys_info
-echo "::endgroup::"
+if [[ "$CI_OS" == "windows-2022" ]]; then
+    echo "Skipping mne sys_info (hangs sometimes!)"
+else
+    echo "::group::Testing mne sys_info"
+    mne sys_info || exit 1
+    echo "::endgroup::"
+fi
 
 echo "::group::Testing import of MNE and all additional packages included in the installer"
 python -u tests/test_imports.py

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -20,6 +20,11 @@ echo "::group::pip list"
 pip list
 echo "::endgroup::"
 
+echo "::group::package sizes"
+# https://stackoverflow.com/a/67976448/2175965
+grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed 's/.*conda-meta\///g' | column -t
+echo "::endgroup::"
+
 echo "::group::Platform specific tests for MNE_MACHINE=$MNE_MACHINE"
 if [[ "$MNE_MACHINE" == "macOS" ]]; then
     echo "Testing that file permissions are set correctly (owned by "$USER", not "root".)"

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -32,7 +32,7 @@ echo "::endgroup::"
 MAX_SIZE=2147483648
 # I hate macOS sometimes
 if [[ "$MNE_MACHINE" == "macOS" ]]; then
-    SIZE_OPT="-f%s"
+    SIZE_OPT="-f%c"
 else
     SIZE_OPT="-c%s"
 fi

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -23,7 +23,8 @@ echo "::endgroup::"
 N=100
 echo "::group::package sizes (top $N)"
 # https://stackoverflow.com/a/67976448/2175965
-grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed 's/.*conda-meta\///g' | sed 's/"size": //g' | head -n $N | column -t
+grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed 's/.*conda-meta\///g' | sed 's/"size": //g' > package_sizes.txt
+head -n $N package_sizes.txt
 echo "::endgroup::"
 
 # Now that we have the package sizes listed, raise an error if the installer is too big

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -25,6 +25,15 @@ echo "::group::package sizes"
 grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed 's/.*conda-meta\///g' | column -t
 echo "::endgroup::"
 
+# Now that we have the package sizes listed, raise an error if the installer is too big
+# (it will fail to attach to GH releases)
+MAX_SIZE=2147483648
+actual_size=$(stat -c%s "$MNE_INSTALLER_NAME")
+if [ "$actual_size" -gt "$MAX_SIZE" ]; then
+    echo "Error: Installer size ($actual_size bytes) exceeds the maximum allowed size ($MAX_SIZE bytes)."
+    exit 1
+fi
+
 echo "::group::Platform specific tests for MNE_MACHINE=$MNE_MACHINE"
 if [[ "$MNE_MACHINE" == "macOS" ]]; then
     echo "Testing that file permissions are set correctly (owned by "$USER", not "root".)"

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -23,7 +23,7 @@ echo "::endgroup::"
 N=100
 echo "::group::package sizes (top $N)"
 # https://stackoverflow.com/a/67976448/2175965
-grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed -E 's/.*conda-meta\/(.+)\.json:\s+"size": (.+),/\1 \2/g' > package_sizes.txt
+grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed -E 's/.*conda-meta\/(.+)\.json:.+"size": (.+),/\1 \2/g' > package_sizes.txt
 head -n $N package_sizes.txt | column -t
 echo "::endgroup::"
 

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -23,7 +23,7 @@ echo "::endgroup::"
 N=100
 echo "::group::package sizes (top $N)"
 # https://stackoverflow.com/a/67976448/2175965
-grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed 's/.*conda-meta\///g' | sed 's/"size": //g' > package_sizes.txt
+grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed 's/.*conda-meta\///g' | sed 's/"size": //g' | sed 's/,$//' > package_sizes.txt
 head -n $N package_sizes.txt | column -t
 echo "::endgroup::"
 

--- a/tools/check_installation.sh
+++ b/tools/check_installation.sh
@@ -24,7 +24,7 @@ N=100
 echo "::group::package sizes (top $N)"
 # https://stackoverflow.com/a/67976448/2175965
 grep '"size":' ${CONDA_PREFIX}/conda-meta/*.json | sort -k3rn | sed 's/.*conda-meta\///g' | sed 's/"size": //g' > package_sizes.txt
-head -n $N package_sizes.txt
+head -n $N package_sizes.txt | column -t
 echo "::endgroup::"
 
 # Now that we have the package sizes listed, raise an error if the installer is too big


### PR DESCRIPTION
Our release action [failed](https://github.com/mne-tools/mne-installers/actions/runs/24699126101/job/72246241839#step:4:22) to attach the Linux script:
```
Warning: Failed to upload artifact MNE-Python-1.12.1_0-Linux.sh. Validation Failed: {"resource":"ReleaseAsset","code":"custom","field":"size","message":"size must be less than 2147483648"} - https://docs.github.com/rest.
```
I also couldn't upload it manually:

<img width="929" height="150" alt="image" src="https://github.com/user-attachments/assets/f7b13cac-a4f2-4c9a-af7c-2334d4c6e7e4" />

So let's:

- [x] Add a check to the installer hash script to `exit 1` if the installer is too big
- [x] Figure out which package is causing the problem by using https://stackoverflow.com/a/67976448/2175965
- [x] Remove package(s) needed to get Linux below 2GB
- [x] Take the resulting artifact and add it to our current release
- [x] Mark PR for merge