### PR TITLE
MAINT: Improve outdated infrastructure

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ channels:
   - conda-forge
 
 dependencies:
-  - constructor >=3.6.0
+  - constructor >=3.15.3
   - conda-libmamba-solver
   - conda-standalone >=23.11.0,!=24.11.0
   - menuinst
-  - conda >=23.11.0,!=26.3.1,!=26.3.2
+  - conda >=23.11.0

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -67,8 +67,8 @@ specs:
   - pip =26.0.1
   - wheel =0.47.0
   - conda =26.3.2
-  - mamba =2.5.0
-  - libmamba =2.5.0
+  - mamba =2.6.0
+  - libmamba =2.6.0
   # MNE ecosystem
   - mne-installer-menu =1.12.1=*  # locally_built
   # TODO: ⛔️ ⛔️ ⛔️ DEV BUILDS START: CHANGE BEFORE RELEASE! ⛔️ ⛔️ ⛔️
@@ -117,12 +117,12 @@ specs:
   - fooof =1.1.1
   - pybispectra =1.3.1
   # Microstates
-  - mne-microstates =0.3.0
+  - mne-microstates =0.3
   - pycrostates =0.6.1
   # OpenNeuro.org data access
   - openneuro-py =2026.4.1
   # sleep staging
-  - sleepecg =0.5.9=*_2
+  - sleepecg =0.5.9
   - yasa =0.7.0
   # various biological signals (ECG, EOG, EMG, …)
   - neurokit2 =0.2.13
@@ -176,15 +176,15 @@ specs:
   - imageio-ffmpeg =0.6.0
   - pandas =3.0.2
   - polars =1.40.0
-  - numpy =2.4.3  # [not (osx and x86_64)]
-  - numpy =2.3.5  # [osx and x86_64]  # allow_outdated, numba
+  - numpy =2.4.3
   - scipy =1.17.1
   - openblas =0.3.32  # allow_outdated, needs libblas update
   - libblas =3.11.0*=*openblas
   - jupyter =1.1.1
   - notebook =7.5.5
   - nbconvert =7.17.1
-  - jupyterlab =4.5.6
+  - onnxruntime =1.24.2
+  - jupyterlab =4.5.7
   - ipykernel =6.31.0  # allow_outdated, 7+ incompatible with spyder_kernels 3.1.3
   - spyder-kernels =3.1.4
   # TODO: Needs to not require pyqt
@@ -192,8 +192,7 @@ specs:
   # spyder =6.1.0
   - darkdetect =0.8.0
   - qdarkstyle =3.2.3
-  - numba =0.65.0  # [not (osx and x86_64)]
-  - numba =0.63.1  # [osx and x86_64]  # allow_outdated, last with first-class support
+  - numba =0.65.1
   - cython =3.2.4
   - joblib =1.5.3
   # I/O
@@ -223,15 +222,15 @@ specs:
   - qtpy =2.4.3
   - seaborn =0.13.2
   - plotly =6.6.0
-  - vtk-base =9.6.0  # allow_outdated, needs proj bug to go away
-  - vtk =9.6.0  # allow_outdated
-  - proj =9.7.1  # allow_outdated, some bug with 9.8.0
+  - vtk-base =9.6.1
+  - vtk =9.6.1
+  - proj =9.8.1
   - ipywidgets =8.1.8
   - pyvista =0.47.3
   - pyvistaqt =0.11.4
   - trame =3.12.0
   - trame-vtk =2.11.8
-  - trame-vuetify =3.2.1
+  - trame-vuetify =3.2.2
   - nest-asyncio2 =1.7.2
   - termcolor =3.3.0
   - defusedxml =0.7.1
@@ -260,7 +259,7 @@ specs:
   - pytest-timeout =2.4.0
   - pre-commit =4.6.0
   - ruff =0.15.11
-  - uv =0.11.7
+  - uv =0.11.8
   - check-manifest =0.51
   - codespell =2.4.2
   - py-spy =0.4.2
@@ -298,6 +297,8 @@ specs:
   - sphinxcontrib-youtube =1.5.0
   - sphinxcontrib-towncrier =0.5.0a0
   - intersphinx-registry =0.2605.27
+  # vvv This line is special so we know what packages to ignore in our JSON version
+  # vvv test, do not change it!
   # OS-specific
   - pythran =0.18.1  # [not win]  # pulls in clang, scipy
   - gfortran =15.2.0  # [not win]  # scipy
@@ -306,6 +307,7 @@ specs:
   - pyobjc-core =12.1  # [osx]
   - pyobjc-framework-Cocoa =12.1  # [osx]
   - pyobjc-framework-FSEvents =12.1  # [osx]
+  # End OS-specific defs
   # Size considerations (must stay under 2GB for releases and Windows!):
   # - r-base and rpy2 add too many dependencies, so we don't add them
   # - constructor adds conda-standalone, which is ~50 MB

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -183,7 +183,8 @@ specs:
   - jupyter =1.1.1
   - notebook =7.5.5
   - nbconvert =7.17.1
-  - onnxruntime =1.24.2
+  - onnxruntime =1.24.2  # [not osx and x86_64]
+  - onnxruntime =1.22.2  # [osx and x86_64]  # allow_outdated, last version they made
   - jupyterlab =4.5.7
   - ipykernel =6.31.0  # allow_outdated, 7+ incompatible with spyder_kernels 3.1.3
   - spyder-kernels =3.1.4

--- a/recipes/mne-python/construct.yaml
+++ b/recipes/mne-python/construct.yaml
@@ -183,8 +183,6 @@ specs:
   - jupyter =1.1.1
   - notebook =7.5.5
   - nbconvert =7.17.1
-  - onnxruntime =1.24.2  # [not osx and x86_64]
-  - onnxruntime =1.22.2  # [osx and x86_64]  # allow_outdated, last version they made
   - jupyterlab =4.5.7
   - ipykernel =6.31.0  # allow_outdated, 7+ incompatible with spyder_kernels 3.1.3
   - spyder-kernels =3.1.4
@@ -301,6 +299,8 @@ specs:
   # vvv This line is special so we know what packages to ignore in our JSON version
   # vvv test, do not change it!
   # OS-specific
+  - onnxruntime =1.24.2  # [not osx and x86_64]
+  - onnxruntime =1.22.2  # [osx and x86_64]  # allow_outdated, last version they made
   - pythran =0.18.1  # [not win]  # pulls in clang, scipy
   - gfortran =15.2.0  # [not win]  # scipy
   - git =2.53.0  # [win]

--- a/tests/test_json_versions.py
+++ b/tests/test_json_versions.py
@@ -33,23 +33,25 @@ construct_yaml_path = recipe_dir / "construct.yaml"
 params = yaml.safe_load(construct_yaml_path.read_text(encoding="utf-8"))
 installer_version = params["version"]
 specs = params["specs"]
+construct_lines = construct_yaml_path.read_text("utf-8").splitlines()
 del params
 
 # Extract versions from construct.yaml
 want_versions = {}
 for spec in specs:
-    if " =" not in spec or spec.count("=") < 2:
+    if not spec.count("="):
         continue
     package_name, package_version_and_build = spec.split(" ")
-    package_version = package_version_and_build.split("=")[1].rstrip("*")
-    package_build = package_version_and_build.split("=")[-1]
+    spec_parts = package_version_and_build.split("=")[1:]
+    package_version = spec_parts[0].rstrip("*")
+    package_build = spec_parts[1] if len(spec_parts) > 1 else None
     want_versions[package_name] = {
         "version": package_version,
         "build_string": package_build,
     }
-for name in ("mne", "mne-installer-menu"):  # the most important ones!
-    assert name in want_versions, f"{name} missing from want_versions (build str error)"
-assert len(want_versions) > 2, len(want_versions)  # more than just the two above
+# for name in ("mne", "mne-installer-menu"):  # the most important ones!
+#     assert name in want_versions, f"{name} missing from construct.yml versions"
+assert len(want_versions) > 50, want_versions  # lots of packages with version specs
 
 # Extract versions from created environment
 fname = dir_ / f"MNE-Python-{installer_version}-{sys_name}{sys_ext}.env.json"
@@ -62,9 +64,22 @@ for package in env_json:
         "build_string": str(package["build_string"]),
     }
 
+start = construct_lines.index("  # OS-specific")
+stop = construct_lines.index("  # End OS-specific defs")
+ignores = [line.strip() for line in construct_lines[start:stop]]
+ignores = [
+    line.split("#")[0].split("=")[0][2:].strip()
+    for line in ignores
+    if not line.startswith("#")
+]
+ignores += ["numpy", "numba"]
 # check versions
 for package_name, want in tqdm(want_versions.items(), desc="Versions", unit="package"):
+    if package_name in ignores:
+        continue
+    assert package_name in got_versions, f"{package_name} missing from env.json"
     got = got_versions[package_name]
     msg = f"{package_name}: got {repr(got)} != want {repr(want)}"
     assert got["version"] == want["version"], msg
-    assert fnmatch.fnmatch(got["build_string"], want["build_string"]), msg
+    if want["build_string"] is not None:
+        assert fnmatch.fnmatch(got["build_string"], want["build_string"]), msg

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -174,22 +174,23 @@ for package in packages:
         not_found.append(package)
         continue
 
-    # Iterate in reverse chronological order, omitting versions marked as broken and
     # those that are not in the main channel
     # TODO We may want to make exceptions here for MNE testing versions if we need them
-    version = None
-    for file in json["files"][::-1]:
+    version = "0.0"
+    for file in json["files"]:
+        # Omitting versions marked as broken, dev, and those not in the main channel
         if "broken" in file["labels"]:
             continue
-        elif "main" not in file["labels"]:
+        if "dev" in file["labels"]:
             continue
-        elif ".rc" in file["version"]:
+        if "main" not in file["labels"]:
             continue
-        else:
+        if ".rc" in file["version"]:
+            continue
+        if packaging.version.parse(file["version"]) > packaging.version.parse(version):
             version = file["version"]
-            break
 
-    assert version is not None
+    assert version != "0.0", f"Did not find a valid version for {package.name}"
 
     package.version_conda_forge = version
     del json, version


### PR DESCRIPTION
The non-3.14-specific improvements from https://github.com/mne-tools/mne-installers/pull/434, might as well get them in while we wait for `onnxruntime`